### PR TITLE
Add Product.NeedsMet component to Product.Item content type

### DIFF
--- a/src/api/product/content-types/item/schema.json
+++ b/src/api/product/content-types/item/schema.json
@@ -37,6 +37,11 @@
       "type": "component",
       "repeatable": false,
       "component": "product.product-weight"
+    },
+    "needsMet": {
+      "type": "component",
+      "repeatable": false,
+      "component": "product.needs-met"
     }
   }
 }

--- a/src/components/product/needs-met.json
+++ b/src/components/product/needs-met.json
@@ -1,0 +1,29 @@
+{
+  "collectionName": "components_product_needs_mets",
+  "info": {
+    "displayName": "Needs Met",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "Items": {
+      "type": "integer"
+    },
+    "People": {
+      "type": "integer"
+    },
+    "Type": {
+      "type": "enumeration",
+      "enum": ["DA", "SPHERE"]
+    },
+    "Months": {
+      "type": "integer"
+    },
+    "MonthlyNeedsMetPerUnit": {
+      "type": "integer"
+    },
+    "Notes": {
+      "type": "text"
+    }
+  }
+}

--- a/src/components/product/needs-met.json
+++ b/src/components/product/needs-met.json
@@ -14,13 +14,16 @@
     },
     "Type": {
       "type": "enumeration",
-      "enum": ["DA", "SPHERE"]
+      "enum": [
+        "DA",
+        "SPHERE"
+      ]
     },
     "Months": {
       "type": "integer"
     },
     "MonthlyNeedsMetPerUnit": {
-      "type": "integer"
+      "type": "decimal"
     },
     "Notes": {
       "type": "text"

--- a/types/generated/components.d.ts
+++ b/types/generated/components.d.ts
@@ -23,7 +23,7 @@ export interface ProductNeedsMet extends Schema.Component {
     People: Attribute.Integer;
     Type: Attribute.Enumeration<['DA', 'SPHERE']>;
     Months: Attribute.Integer;
-    MonthlyNeedsMetPerUnit: Attribute.Integer;
+    MonthlyNeedsMetPerUnit: Attribute.Decimal;
     Notes: Attribute.Text;
   };
 }

--- a/types/generated/components.d.ts
+++ b/types/generated/components.d.ts
@@ -12,6 +12,22 @@ export interface GeoLocation extends Schema.Component {
   };
 }
 
+export interface ProductNeedsMet extends Schema.Component {
+  collectionName: 'components_product_needs_mets';
+  info: {
+    displayName: 'Needs Met';
+    description: '';
+  };
+  attributes: {
+    Items: Attribute.Integer;
+    People: Attribute.Integer;
+    Type: Attribute.Enumeration<['DA', 'SPHERE']>;
+    Months: Attribute.Integer;
+    MonthlyNeedsMetPerUnit: Attribute.Integer;
+    Notes: Attribute.Text;
+  };
+}
+
 export interface ProductProductWeight extends Schema.Component {
   collectionName: 'components_product_product_weights';
   info: {
@@ -94,6 +110,7 @@ declare module '@strapi/types' {
   export module Shared {
     export interface Components {
       'geo.location': GeoLocation;
+      'product.needs-met': ProductNeedsMet;
       'product.product-weight': ProductProductWeight;
       'product.volume': ProductVolume;
       'team.role': TeamRole;

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -403,9 +403,12 @@ export interface PluginUploadFile extends Schema.CollectionType {
     folderPath: Attribute.String &
       Attribute.Required &
       Attribute.Private &
-      Attribute.SetMinMax<{
-        min: 1;
-      }>;
+      Attribute.SetMinMax<
+        {
+          min: 1;
+        },
+        number
+      >;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
     createdBy: Attribute.Relation<
@@ -441,9 +444,12 @@ export interface PluginUploadFolder extends Schema.CollectionType {
   attributes: {
     name: Attribute.String &
       Attribute.Required &
-      Attribute.SetMinMax<{
-        min: 1;
-      }>;
+      Attribute.SetMinMax<
+        {
+          min: 1;
+        },
+        number
+      >;
     pathId: Attribute.Integer & Attribute.Required & Attribute.Unique;
     parent: Attribute.Relation<
       'plugin::upload.folder',
@@ -462,9 +468,12 @@ export interface PluginUploadFolder extends Schema.CollectionType {
     >;
     path: Attribute.String &
       Attribute.Required &
-      Attribute.SetMinMax<{
-        min: 1;
-      }>;
+      Attribute.SetMinMax<
+        {
+          min: 1;
+        },
+        number
+      >;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
     createdBy: Attribute.Relation<
@@ -543,10 +552,13 @@ export interface PluginI18NLocale extends Schema.CollectionType {
   };
   attributes: {
     name: Attribute.String &
-      Attribute.SetMinMax<{
-        min: 1;
-        max: 50;
-      }>;
+      Attribute.SetMinMax<
+        {
+          min: 1;
+          max: 50;
+        },
+        number
+      >;
     code: Attribute.String & Attribute.Unique;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
@@ -901,6 +913,7 @@ export interface ApiProductItem extends Schema.CollectionType {
     >;
     volume: Attribute.Component<'product.volume', true>;
     weight: Attribute.Component<'product.product-weight'>;
+    needsMet: Attribute.Component<'product.needs-met'>;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
     publishedAt: Attribute.DateTime;


### PR DESCRIPTION
Closes #15 
Adds a `Product.NeedsMet` component to the `Product.Item` content type in the Strapi CMS

Have a couple questions: 
1. Re the `Type` field: Are `DA` and `SPHERE` the only options?
2. What does `DA` stand for? Should we use the full name instead of `DA`?
3. Plain text is ok for the `Notes` field?