### PR TITLE
feat(data-modeling): Create NeedsAssessment.Need collection type

### DIFF
--- a/src/api/needs-assessment/content-types/need/schema.json
+++ b/src/api/needs-assessment/content-types/need/schema.json
@@ -11,23 +11,23 @@
   },
   "pluginOptions": {},
   "attributes": {
-    "needs_assessment_survey": {
+    "survey": {
       "type": "relation",
       "relation": "manyToOne",
       "target": "api::needs-assessment.survey",
       "inversedBy": "needs_assessment_needs"
     },
-    "geo_region": {
+    "region": {
       "type": "relation",
       "relation": "oneToOne",
       "target": "api::geo.region"
     },
-    "geo_subregion": {
+    "subregion": {
       "type": "relation",
       "relation": "oneToOne",
       "target": "api::geo.subregion"
     },
-    "product_item": {
+    "item": {
       "type": "relation",
       "relation": "oneToOne",
       "target": "api::product.item"

--- a/src/api/needs-assessment/content-types/need/schema.json
+++ b/src/api/needs-assessment/content-types/need/schema.json
@@ -15,7 +15,7 @@
       "type": "relation",
       "relation": "manyToOne",
       "target": "api::needs-assessment.survey",
-      "inversedBy": "needs_assessment_needs"
+      "inversedBy": "needs"
     },
     "region": {
       "type": "relation",

--- a/src/api/needs-assessment/content-types/need/schema.json
+++ b/src/api/needs-assessment/content-types/need/schema.json
@@ -1,0 +1,40 @@
+{
+  "kind": "collectionType",
+  "collectionName": "needs",
+  "info": {
+    "singularName": "need",
+    "pluralName": "needs",
+    "displayName": "NeedsAssessment.Need"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "needs_assessment_survey": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::needs-assessment.survey",
+      "inversedBy": "needs_assessment_needs"
+    },
+    "geo_region": {
+      "type": "relation",
+      "relation": "oneToOne",
+      "target": "api::geo.region"
+    },
+    "geo_subregion": {
+      "type": "relation",
+      "relation": "oneToOne",
+      "target": "api::geo.subregion"
+    },
+    "product_item": {
+      "type": "relation",
+      "relation": "oneToOne",
+      "target": "api::product.item"
+    },
+    "need": {
+      "type": "integer",
+      "required": true
+    }
+  }
+}

--- a/src/api/needs-assessment/content-types/survey/schema.json
+++ b/src/api/needs-assessment/content-types/survey/schema.json
@@ -27,7 +27,7 @@
       ],
       "required": true
     },
-    "needs_assessment_needs": {
+    "needs": {
       "type": "relation",
       "relation": "oneToMany",
       "target": "api::needs-assessment.need",

--- a/src/api/needs-assessment/content-types/survey/schema.json
+++ b/src/api/needs-assessment/content-types/survey/schema.json
@@ -1,4 +1,3 @@
-
 {
   "kind": "collectionType",
   "collectionName": "surveys",
@@ -27,6 +26,12 @@
         "Q4"
       ],
       "required": true
+    },
+    "needs_assessment_needs": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::needs-assessment.need",
+      "mappedBy": "needs_assessment_survey"
     }
   }
 }

--- a/src/api/needs-assessment/controllers/need.ts
+++ b/src/api/needs-assessment/controllers/need.ts
@@ -1,0 +1,7 @@
+/**
+ * need controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::needs-assessment.need');

--- a/src/api/needs-assessment/routes/need.ts
+++ b/src/api/needs-assessment/routes/need.ts
@@ -1,0 +1,7 @@
+/**
+ * need router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::needs-assessment.need');

--- a/src/api/needs-assessment/services/need.ts
+++ b/src/api/needs-assessment/services/need.ts
@@ -1,0 +1,7 @@
+/**
+ * need service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::needs-assessment.need');

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -1017,22 +1017,22 @@ export interface ApiNeedsAssessmentNeed extends Schema.CollectionType {
     draftAndPublish: true;
   };
   attributes: {
-    needs_assessment_survey: Attribute.Relation<
+    survey: Attribute.Relation<
       'api::needs-assessment.need',
       'manyToOne',
       'api::needs-assessment.survey'
     >;
-    geo_region: Attribute.Relation<
+    region: Attribute.Relation<
       'api::needs-assessment.need',
       'oneToOne',
       'api::geo.region'
     >;
-    geo_subregion: Attribute.Relation<
+    subregion: Attribute.Relation<
       'api::needs-assessment.need',
       'oneToOne',
       'api::geo.subregion'
     >;
-    product_item: Attribute.Relation<
+    item: Attribute.Relation<
       'api::needs-assessment.need',
       'oneToOne',
       'api::product.item'

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -1075,7 +1075,7 @@ export interface ApiNeedsAssessmentSurvey extends Schema.CollectionType {
       }>;
     quarter: Attribute.Enumeration<['Q1', 'Q2', 'Q3', 'Q4']> &
       Attribute.Required;
-    needs_assessment_needs: Attribute.Relation<
+    needs: Attribute.Relation<
       'api::needs-assessment.survey',
       'oneToMany',
       'api::needs-assessment.need'

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -1006,6 +1006,56 @@ export interface ApiGeoSubregion extends Schema.CollectionType {
   };
 }
 
+export interface ApiNeedsAssessmentNeed extends Schema.CollectionType {
+  collectionName: 'needs';
+  info: {
+    singularName: 'need';
+    pluralName: 'needs';
+    displayName: 'NeedsAssessment.Need';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    needs_assessment_survey: Attribute.Relation<
+      'api::needs-assessment.need',
+      'manyToOne',
+      'api::needs-assessment.survey'
+    >;
+    geo_region: Attribute.Relation<
+      'api::needs-assessment.need',
+      'oneToOne',
+      'api::geo.region'
+    >;
+    geo_subregion: Attribute.Relation<
+      'api::needs-assessment.need',
+      'oneToOne',
+      'api::geo.subregion'
+    >;
+    product_item: Attribute.Relation<
+      'api::needs-assessment.need',
+      'oneToOne',
+      'api::product.item'
+    >;
+    need: Attribute.Integer & Attribute.Required;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::needs-assessment.need',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::needs-assessment.need',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
 export interface ApiNeedsAssessmentSurvey extends Schema.CollectionType {
   collectionName: 'surveys';
   info: {
@@ -1025,6 +1075,11 @@ export interface ApiNeedsAssessmentSurvey extends Schema.CollectionType {
       }>;
     quarter: Attribute.Enumeration<['Q1', 'Q2', 'Q3', 'Q4']> &
       Attribute.Required;
+    needs_assessment_needs: Attribute.Relation<
+      'api::needs-assessment.survey',
+      'oneToMany',
+      'api::needs-assessment.need'
+    >;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
     publishedAt: Attribute.DateTime;
@@ -1193,6 +1248,7 @@ declare module '@strapi/types' {
       'api::geo.country': ApiGeoCountry;
       'api::geo.region': ApiGeoRegion;
       'api::geo.subregion': ApiGeoSubregion;
+      'api::needs-assessment.need': ApiNeedsAssessmentNeed;
       'api::needs-assessment.survey': ApiNeedsAssessmentSurvey;
       'api::product.category': ApiProductCategory;
       'api::product.item': ApiProductItem;


### PR DESCRIPTION
Resolves #44 

Creates NeedsAssessment.Need collection type for the needs data.

_**Note**_: There is not an option to have a relation field type as "required" in the Strapi admin currently, therefore all relations for this collection exist as inputs that are not required.