### PR TITLE
feat: add custom calculations to component fields via content-manager plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,7 @@ ssl
 nbproject
 public/uploads/*
 !public/uploads/.gitkeep
+.vscode
 
 ############################
 # Node.js

--- a/src/api/product/content-types/item/schema.json
+++ b/src/api/product/content-types/item/schema.json
@@ -35,8 +35,8 @@
     },
     "weight": {
       "type": "component",
-      "repeatable": false,
-      "component": "product.product-weight"
+      "repeatable": true,
+      "component": "product.weight"
     },
     "needsMet": {
       "type": "component",

--- a/src/api/product/controllers/category.ts
+++ b/src/api/product/controllers/category.ts
@@ -4,4 +4,28 @@
 
 import { factories } from '@strapi/strapi'
 
-export default factories.createCoreController('api::product.category');
+export default factories.createCoreController('api::product.category', ({ strapi }) => ({
+    async find(ctx) {
+        const result = await super.find(ctx);
+        strapi.log.info(`result of category find: ${JSON.stringify(result)}`);
+        return result;
+    },
+
+    async findOne(ctx) {
+        const result = await super.findOne(ctx);
+        strapi.log.info(`result of category findOne: ${JSON.stringify(result)}`);
+        return result;
+    },
+
+    async create(ctx) {
+        const result = await super.create(ctx);
+        strapi.log.info(`result of category create: ${JSON.stringify(result)}`);
+        return result;
+    },
+
+    async update(ctx) {
+        const result = await super.update(ctx);
+        strapi.log.info(`result of category update: ${JSON.stringify(result)}`);
+        return result;
+    }
+}));

--- a/src/api/product/controllers/item.ts
+++ b/src/api/product/controllers/item.ts
@@ -4,4 +4,28 @@
 
 import { factories } from '@strapi/strapi'
 
-export default factories.createCoreController('api::product.item');
+export default factories.createCoreController('api::product.item', ({ strapi }) => ({
+    async find(ctx) {
+        const result = await super.find(ctx);
+        strapi.log.info(`result of find: ${JSON.stringify(result)}`);
+        return result;
+    },
+
+    async findOne(ctx) {
+        const result = await super.findOne(ctx);
+        strapi.log.info(`result of findOne: ${JSON.stringify(result)}`);
+        return result;
+    },
+
+    async create(ctx) {
+        const result = await super.create(ctx);
+        strapi.log.info(`result of create: ${JSON.stringify(result)}`);
+        return result;
+    },
+
+    async update(ctx) {
+        const result = await super.update(ctx);
+        strapi.log.info(`result of update: ${JSON.stringify(result)}`);
+        return result;
+    }
+}));

--- a/src/api/product/controllers/item.ts
+++ b/src/api/product/controllers/item.ts
@@ -8,26 +8,26 @@ export default factories.createCoreController(
   "api::product.item",
   ({ strapi }) => ({
     async find(ctx) {
+      strapi.log.info(`API FIND: ${JSON.stringify(ctx.request)}`);
       const result = await super.find(ctx);
-      strapi.log.info(`API FIND: ${JSON.stringify(result)}`);
       return result;
     },
 
     async findOne(ctx) {
+      strapi.log.info(`API FINDONE: ${JSON.stringify(ctx.request)}`);
       const result = await super.findOne(ctx);
-      strapi.log.info(`API FINDONE: ${JSON.stringify(result)}`);
       return result;
     },
 
     async create(ctx) {
+      strapi.log.info(`API CREATE: ${JSON.stringify(ctx.request.body)}`);
       const result = await super.create(ctx);
-      strapi.log.info(`API CREATE: ${JSON.stringify(result)}`);
       return result;
     },
 
     async update(ctx) {
+      strapi.log.info(`API UPDATE: ${JSON.stringify(ctx.request.body)}`);
       const result = await super.update(ctx);
-      strapi.log.info(`API UPDATE: ${JSON.stringify(result)}`);
       return result;
     },
   })

--- a/src/api/product/controllers/item.ts
+++ b/src/api/product/controllers/item.ts
@@ -2,30 +2,33 @@
  * item controller
  */
 
-import { factories } from '@strapi/strapi'
+import { factories } from "@strapi/strapi";
 
-export default factories.createCoreController('api::product.item', ({ strapi }) => ({
+export default factories.createCoreController(
+  "api::product.item",
+  ({ strapi }) => ({
     async find(ctx) {
-        const result = await super.find(ctx);
-        strapi.log.info(`result of find: ${JSON.stringify(result)}`);
-        return result;
+      const result = await super.find(ctx);
+      strapi.log.info(`API FIND: ${JSON.stringify(result)}`);
+      return result;
     },
 
     async findOne(ctx) {
-        const result = await super.findOne(ctx);
-        strapi.log.info(`result of findOne: ${JSON.stringify(result)}`);
-        return result;
+      const result = await super.findOne(ctx);
+      strapi.log.info(`API FINDONE: ${JSON.stringify(result)}`);
+      return result;
     },
 
     async create(ctx) {
-        const result = await super.create(ctx);
-        strapi.log.info(`result of create: ${JSON.stringify(result)}`);
-        return result;
+      const result = await super.create(ctx);
+      strapi.log.info(`API CREATE: ${JSON.stringify(result)}`);
+      return result;
     },
 
     async update(ctx) {
-        const result = await super.update(ctx);
-        strapi.log.info(`result of update: ${JSON.stringify(result)}`);
-        return result;
-    }
-}));
+      const result = await super.update(ctx);
+      strapi.log.info(`API UPDATE: ${JSON.stringify(result)}`);
+      return result;
+    },
+  })
+);

--- a/src/components/product/volume.json
+++ b/src/components/product/volume.json
@@ -7,21 +7,24 @@
   "options": {},
   "attributes": {
     "packageVolume": {
-      "type": "decimal"
+      "type": "decimal",
+      "required": true,
+      "customErrorMessage": {
+        "type": "packageVolume must be a number.",
+        "required": "packageVolume cannot be empty."
+      }
     },
     "volumeUnit": {
       "type": "enumeration",
-      "enum": [
-        "cubic in",
-        "cubic cm",
-        "cubic ft",
-        "cubic m"
-      ],
-      "default": "cubic in"
+      "enum": ["cubic in", "cubic cm", "cubic ft", "cubic m"],
+      "default": "cubic in",
+      "required": true
     },
     "countPerPackage": {
       "type": "integer",
-      "default": 1
+      "required": true,
+      "default": 1,
+      "min": 1
     },
     "itemVolumeCBCM": {
       "type": "decimal"
@@ -30,10 +33,12 @@
       "type": "decimal"
     },
     "volumeSource": {
-      "type": "string"
+      "type": "string",
+      "required": true
     },
     "logDate": {
-      "type": "date"
+      "type": "date",
+      "required": true
     },
     "notes": {
       "type": "text"

--- a/src/components/product/volume.json
+++ b/src/components/product/volume.json
@@ -1,7 +1,8 @@
 {
   "collectionName": "components_product_volumes",
   "info": {
-    "displayName": "Volume"
+    "displayName": "Volume",
+    "description": ""
   },
   "options": {},
   "attributes": {
@@ -23,10 +24,10 @@
       "default": 1
     },
     "itemVolumeCBCM": {
-      "type": "biginteger"
+      "type": "decimal"
     },
     "countPerCBM": {
-      "type": "biginteger"
+      "type": "decimal"
     },
     "volumeSource": {
       "type": "string"

--- a/src/components/product/weight.json
+++ b/src/components/product/weight.json
@@ -10,9 +10,15 @@
       "type": "decimal",
       "required": true
     },
+    "packageWeightUnit": {
+      "type": "enumeration",
+      "enum": ["lb", "oz", "g", "kg"],
+      "required": true
+    },
     "countPerPackage": {
       "type": "integer",
-      "required": true
+      "required": true,
+      "min": 1
     },
     "itemWeightKg": {
       "type": "decimal"
@@ -30,10 +36,6 @@
     },
     "notes": {
       "type": "string"
-    },
-    "packageWeightUnit": {
-      "type": "enumeration",
-      "enum": ["lb", "oz", "g", "kg"]
     }
   }
 }

--- a/src/components/product/weight.json
+++ b/src/components/product/weight.json
@@ -1,7 +1,7 @@
 {
-  "collectionName": "components_product_product_weights",
+  "collectionName": "components_product_weights",
   "info": {
-    "displayName": "Product Weight",
+    "displayName": "Weight",
     "description": ""
   },
   "options": {},
@@ -33,12 +33,7 @@
     },
     "packageWeightUnit": {
       "type": "enumeration",
-      "enum": [
-        "lb",
-        "oz",
-        "g",
-        "kg"
-      ]
+      "enum": ["lb", "oz", "g", "kg"]
     }
   }
 }

--- a/src/extensions/content-manager/strapi-server.ts
+++ b/src/extensions/content-manager/strapi-server.ts
@@ -1,0 +1,106 @@
+module.exports = (plugin) => {
+  let originalCreate = plugin.controllers["collection-types"].create;
+  plugin.controllers["collection-types"].create = (ctx) => {
+    if (isProductItem(ctx)) {
+      for (let i = 0; i < ctx.request.body.weight.length; i++) {
+        ctx.request.body.weight[i] = calculateWeightFields(
+          ctx.request.body.weight[i]
+        );
+      }
+
+      for (let i = 0; i < ctx.request.body.volume.length; i++) {
+        ctx.request.body.volume[i] = calculateVolumeFields(
+          ctx.request.body.volume[i]
+        );
+      }
+    }
+
+    return originalCreate(ctx);
+  };
+
+  let originalUpdate = plugin.controllers["collection-types"].update;
+  plugin.controllers["collection-types"].update = (ctx) => {
+    if (isProductItem(ctx)) {
+      for (let i = 0; i < ctx.request.body.weight.length; i++) {
+        ctx.request.body.weight[i] = calculateWeightFields(
+          ctx.request.body.weight[i]
+        );
+      }
+
+      for (let i = 0; i < ctx.request.body.volume.length; i++) {
+        ctx.request.body.volume[i] = calculateVolumeFields(
+          ctx.request.body.volume[i]
+        );
+      }
+    }
+
+    return originalUpdate(ctx);
+  };
+
+  return plugin;
+};
+
+function isProductItem(ctx) {
+  return ctx.request.path.includes("api::product.item");
+}
+
+function calculateWeightFields(data) {
+  const { packageWeight, countPerPackage, packageWeightUnit } = data;
+
+  const normalizedPagkageWeight = normalizeToKg(
+    packageWeight,
+    packageWeightUnit
+  );
+
+  let itemWeightKg = normalizedPagkageWeight / countPerPackage;
+  let countPerKg = 1 / itemWeightKg;
+
+  itemWeightKg = parseFloat(itemWeightKg.toFixed(2));
+  countPerKg = parseFloat(countPerKg.toFixed(2));
+
+  return { ...data, itemWeightKg, countPerKg };
+}
+
+function calculateVolumeFields(data) {
+  const { packageVolume, countPerPackage, volumeUnit } = data;
+
+  const normalizedPagkageVolume = normalizeToCM(packageVolume, volumeUnit);
+
+  let itemVolumeCBCM = normalizedPagkageVolume / countPerPackage;
+  let countPerCBM = 1000000 / itemVolumeCBCM;
+
+  itemVolumeCBCM = parseFloat(itemVolumeCBCM.toFixed(2));
+  countPerCBM = parseFloat(countPerCBM.toFixed(2));
+
+  return { ...data, itemVolumeCBCM, countPerCBM };
+}
+
+function normalizeToKg(weight, unit) {
+  switch (unit) {
+    case "lb":
+      return weight * 0.45359237;
+    case "oz":
+      return weight * 0.0283495231;
+    case "g":
+      return weight * 0.001;
+    case "kg":
+      return weight;
+    default:
+      throw new Error(`Unsupported weight unit: ${unit}`);
+  }
+}
+
+function normalizeToCM(volume, unit) {
+  switch (unit) {
+    case "cubic ft":
+      return volume * 28316.8;
+    case "cubic in":
+      return volume * 16.387064;
+    case "cubic m":
+      return volume * 1000000;
+    case "cubic cm":
+      return volume;
+    default:
+      throw new Error(`Unsupported volume unit: ${unit}`);
+  }
+}

--- a/types/generated/components.d.ts
+++ b/types/generated/components.d.ts
@@ -28,24 +28,6 @@ export interface ProductNeedsMet extends Schema.Component {
   };
 }
 
-export interface ProductProductWeight extends Schema.Component {
-  collectionName: 'components_product_product_weights';
-  info: {
-    displayName: 'Product Weight';
-    description: '';
-  };
-  attributes: {
-    packageWeight: Attribute.Decimal & Attribute.Required;
-    countPerPackage: Attribute.Integer & Attribute.Required;
-    itemWeightKg: Attribute.Decimal;
-    countPerKg: Attribute.Decimal;
-    weightSource: Attribute.String & Attribute.Required;
-    logDate: Attribute.Date & Attribute.Required;
-    notes: Attribute.String;
-    packageWeightUnit: Attribute.Enumeration<['lb', 'oz', 'g', 'kg']>;
-  };
-}
-
 export interface ProductSecondHand extends Schema.Component {
   collectionName: 'components_product_second_hands';
   info: {
@@ -106,6 +88,24 @@ export interface ProductVolume extends Schema.Component {
   };
 }
 
+export interface ProductWeight extends Schema.Component {
+  collectionName: 'components_product_weights';
+  info: {
+    displayName: 'Weight';
+    description: '';
+  };
+  attributes: {
+    packageWeight: Attribute.Decimal & Attribute.Required;
+    countPerPackage: Attribute.Integer & Attribute.Required;
+    itemWeightKg: Attribute.Decimal;
+    countPerKg: Attribute.Decimal;
+    weightSource: Attribute.String & Attribute.Required;
+    logDate: Attribute.Date & Attribute.Required;
+    notes: Attribute.String;
+    packageWeightUnit: Attribute.Enumeration<['lb', 'oz', 'g', 'kg']>;
+  };
+}
+
 export interface TeamRole extends Schema.Component {
   collectionName: 'components_team_roles';
   info: {
@@ -151,10 +151,10 @@ declare module '@strapi/types' {
     export interface Components {
       'geo.location': GeoLocation;
       'product.needs-met': ProductNeedsMet;
-      'product.product-weight': ProductProductWeight;
       'product.second-hand': ProductSecondHand;
       'product.value': ProductValue;
       'product.volume': ProductVolume;
+      'product.weight': ProductWeight;
       'team.role': TeamRole;
       'time.duration': TimeDuration;
     }

--- a/types/generated/components.d.ts
+++ b/types/generated/components.d.ts
@@ -74,16 +74,25 @@ export interface ProductVolume extends Schema.Component {
     description: '';
   };
   attributes: {
-    packageVolume: Attribute.Decimal;
+    packageVolume: Attribute.Decimal & Attribute.Required;
     volumeUnit: Attribute.Enumeration<
       ['cubic in', 'cubic cm', 'cubic ft', 'cubic m']
     > &
+      Attribute.Required &
       Attribute.DefaultTo<'cubic in'>;
-    countPerPackage: Attribute.Integer & Attribute.DefaultTo<1>;
+    countPerPackage: Attribute.Integer &
+      Attribute.Required &
+      Attribute.SetMinMax<
+        {
+          min: 1;
+        },
+        number
+      > &
+      Attribute.DefaultTo<1>;
     itemVolumeCBCM: Attribute.Decimal;
     countPerCBM: Attribute.Decimal;
-    volumeSource: Attribute.String;
-    logDate: Attribute.Date;
+    volumeSource: Attribute.String & Attribute.Required;
+    logDate: Attribute.Date & Attribute.Required;
     notes: Attribute.Text;
   };
 }
@@ -96,13 +105,21 @@ export interface ProductWeight extends Schema.Component {
   };
   attributes: {
     packageWeight: Attribute.Decimal & Attribute.Required;
-    countPerPackage: Attribute.Integer & Attribute.Required;
+    packageWeightUnit: Attribute.Enumeration<['lb', 'oz', 'g', 'kg']> &
+      Attribute.Required;
+    countPerPackage: Attribute.Integer &
+      Attribute.Required &
+      Attribute.SetMinMax<
+        {
+          min: 1;
+        },
+        number
+      >;
     itemWeightKg: Attribute.Decimal;
     countPerKg: Attribute.Decimal;
     weightSource: Attribute.String & Attribute.Required;
     logDate: Attribute.Date & Attribute.Required;
     notes: Attribute.String;
-    packageWeightUnit: Attribute.Enumeration<['lb', 'oz', 'g', 'kg']>;
   };
 }
 

--- a/types/generated/components.d.ts
+++ b/types/generated/components.d.ts
@@ -89,6 +89,7 @@ export interface ProductVolume extends Schema.Component {
   collectionName: 'components_product_volumes';
   info: {
     displayName: 'Volume';
+    description: '';
   };
   attributes: {
     packageVolume: Attribute.Decimal;
@@ -97,8 +98,8 @@ export interface ProductVolume extends Schema.Component {
     > &
       Attribute.DefaultTo<'cubic in'>;
     countPerPackage: Attribute.Integer & Attribute.DefaultTo<1>;
-    itemVolumeCBCM: Attribute.BigInteger;
-    countPerCBM: Attribute.BigInteger;
+    itemVolumeCBCM: Attribute.Decimal;
+    countPerCBM: Attribute.Decimal;
     volumeSource: Attribute.String;
     logDate: Attribute.Date;
     notes: Attribute.Text;

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -1099,7 +1099,7 @@ export interface ApiProductItem extends Schema.CollectionType {
       'api::product.category'
     >;
     volume: Attribute.Component<'product.volume', true>;
-    weight: Attribute.Component<'product.product-weight'>;
+    weight: Attribute.Component<'product.weight', true>;
     needsMet: Attribute.Component<'product.needs-met'>;
     secondHand: Attribute.Component<'product.second-hand'>;
     value: Attribute.Component<'product.value', true>;


### PR DESCRIPTION
Part of #49
Extends the Strapi `content-manager` plugin to override `create` and `update` methods, allowing us to apply custom calculations to component fields when creating and updating records via the Admin Panel.
Note: these calculations don't apply to records accessed via the API. That will be a separate PR.  

**⚠️ Don't review this yet!** 
Right now this gets the job done for the `weight` and `volume` components. But it's very repetitive and not very flexible. So refactoring to be more flex so it can accommodate additional components (repeating or not) we may add that need custom calculations. 