### PR TITLE
feat: add functionality to perform custom calculations on data entry 

### DIFF
--- a/src/api/product/controllers/item.ts
+++ b/src/api/product/controllers/item.ts
@@ -2,6 +2,31 @@
  * item controller
  */
 
-import { factories } from '@strapi/strapi'
+import { factories } from "@strapi/strapi";
+import { processContentType } from "../../../functions/content-types";
 
-export default factories.createCoreController('api::product.item');
+export default factories.createCoreController(
+  "api::product.item",
+
+  ({ strapi }) => ({
+    async create(ctx) {
+      ctx.request.body.data = processContentType(
+        ctx.request.path,
+        ctx.request.body.data
+      );
+
+      const result = await super.create(ctx);
+      return result;
+    },
+
+    async update(ctx) {
+      ctx.request.body.data = processContentType(
+        ctx.request.path,
+        ctx.request.body.data
+      );
+
+      const result = await super.update(ctx);
+      return result;
+    },
+  })
+);

--- a/src/extensions/content-manager/strapi-server.ts
+++ b/src/extensions/content-manager/strapi-server.ts
@@ -1,0 +1,17 @@
+import { processContentType } from "../../functions/content-types";
+
+module.exports = (plugin) => {
+  let originalCreate = plugin.controllers["collection-types"].create;
+  plugin.controllers["collection-types"].create = (ctx) => {
+    ctx.request.body = processContentType(ctx.request.path, ctx.request.body);
+    return originalCreate(ctx);
+  };
+
+  let originalUpdate = plugin.controllers["collection-types"].update;
+  plugin.controllers["collection-types"].update = (ctx) => {
+    ctx.request.body = processContentType(ctx.request.path, ctx.request.body);
+    return originalUpdate(ctx);
+  };
+
+  return plugin;
+};

--- a/src/functions/content-types/index.ts
+++ b/src/functions/content-types/index.ts
@@ -1,0 +1,34 @@
+import { processProductItem } from "./product/item";
+
+export function processContentType(path, data) {
+  /*
+   Content-manager paths look like this:
+    http://host/admin/content-manager/collection-types/api::product.item/15
+
+   API paths look like this (note the use of the plural version here!)
+    http://host/api/items/15 )
+
+   So need to map both options to the appropriate handler
+  */
+  const contentTypeHandlers = {
+    "product.item": processProductItem,
+    items: processProductItem,
+  };
+
+  const contentType = detectContentType(path);
+
+  const handler = contentTypeHandlers[contentType];
+  if (handler) {
+    return handler(data);
+  }
+}
+
+function detectContentType(path) {
+  if (path.includes("content-manager/collection-types/api::")) {
+    return path.split("api::")[1].split("/")[0];
+  }
+
+  if (path.includes("/api/")) {
+    return path.split("/api/")[1].split("/")[0];
+  }
+}

--- a/src/functions/content-types/product/item.ts
+++ b/src/functions/content-types/product/item.ts
@@ -1,0 +1,79 @@
+export function processProductItem(data) {
+  const componentHandlers = {
+    weight: calculateWeightFields,
+    volume: calculateVolumeFields,
+  };
+
+  for (const [component, handler] of Object.entries(componentHandlers)) {
+    const componentData = data[component];
+    if (componentData) {
+      if (Array.isArray(componentData)) {
+        data[component] = componentData.map(handler) || [];
+      } else {
+        data[component] = handler(componentData);
+      }
+    }
+  }
+  return data;
+}
+
+function calculateWeightFields(data) {
+  const { packageWeight, countPerPackage, packageWeightUnit } = data;
+
+  const normalizedPagkageWeight = normalizeToKg(
+    packageWeight,
+    packageWeightUnit
+  );
+
+  let itemWeightKg = normalizedPagkageWeight / countPerPackage;
+  let countPerKg = 1 / itemWeightKg;
+
+  itemWeightKg = parseFloat(itemWeightKg.toFixed(2));
+  countPerKg = parseFloat(countPerKg.toFixed(2));
+
+  return { ...data, itemWeightKg, countPerKg };
+}
+
+function calculateVolumeFields(data) {
+  const { packageVolume, countPerPackage, volumeUnit } = data;
+
+  const normalizedPagkageVolume = normalizeToCM(packageVolume, volumeUnit);
+
+  let itemVolumeCBCM = normalizedPagkageVolume / countPerPackage;
+  let countPerCBM = 1000000 / itemVolumeCBCM;
+
+  itemVolumeCBCM = parseFloat(itemVolumeCBCM.toFixed(2));
+  countPerCBM = parseFloat(countPerCBM.toFixed(2));
+
+  return { ...data, itemVolumeCBCM, countPerCBM };
+}
+
+function normalizeToKg(weight, unit) {
+  switch (unit) {
+    case "lb":
+      return weight * 0.45359237;
+    case "oz":
+      return weight * 0.0283495231;
+    case "g":
+      return weight * 0.001;
+    case "kg":
+      return weight;
+    default:
+      throw new Error(`Unsupported weight unit: ${unit}`);
+  }
+}
+
+function normalizeToCM(volume, unit) {
+  switch (unit) {
+    case "cubic ft":
+      return volume * 28316.8;
+    case "cubic in":
+      return volume * 16.387064;
+    case "cubic m":
+      return volume * 1000000;
+    case "cubic cm":
+      return volume;
+    default:
+      throw new Error(`Unsupported volume unit: ${unit}`);
+  }
+}


### PR DESCRIPTION
Closes: #49 

Adds functions that allow us to calculate the values of content-type and component fields based on the values of other fields during the data entry process. Works with data entry from either the API or the Admin Panel (Content Manager). 

Specific calculations are implemented for fields in the `Product.info`'s `volume` and `weight` components.