### PR TITLE
Fix: update Product.item components

### DIFF
--- a/src/components/product/needs-met.json
+++ b/src/components/product/needs-met.json
@@ -6,26 +6,23 @@
   },
   "options": {},
   "attributes": {
-    "Items": {
+    "items": {
       "type": "integer"
     },
-    "People": {
+    "people": {
       "type": "integer"
     },
-    "Type": {
+    "type": {
       "type": "enumeration",
-      "enum": [
-        "DA",
-        "SPHERE"
-      ]
+      "enum": ["DA", "SPHERE"]
     },
-    "Months": {
+    "months": {
       "type": "integer"
     },
-    "MonthlyNeedsMetPerUnit": {
+    "monthlyNeedsMetPerUnit": {
       "type": "decimal"
     },
-    "Notes": {
+    "notes": {
       "type": "text"
     }
   }

--- a/src/components/product/needs-met.json
+++ b/src/components/product/needs-met.json
@@ -19,7 +19,7 @@
     "months": {
       "type": "integer"
     },
-    "monthlyNeedsMetPerUnit": {
+    "monthlyNeedsMetPerItem": {
       "type": "decimal"
     },
     "notes": {

--- a/src/components/product/value.json
+++ b/src/components/product/value.json
@@ -9,17 +9,25 @@
     "packagePrice": {
       "type": "decimal"
     },
+    "packagePriceUnit": {
+      "type": "enumeration",
+      "enum": ["USD"],
+      "required": true,
+      "default": "USD"
+    },
     "countPerPackage": {
       "type": "integer"
     },
-    "itemPrice": {
+    "pricePerItemUSD": {
       "type": "decimal"
     },
     "source": {
-      "type": "string"
+      "type": "string",
+      "required": true
     },
     "logDate": {
-      "type": "date"
+      "type": "date",
+      "required": true
     },
     "notes": {
       "type": "text"

--- a/src/components/product/value.json
+++ b/src/components/product/value.json
@@ -6,22 +6,22 @@
   },
   "options": {},
   "attributes": {
-    "Price": {
+    "packagePrice": {
       "type": "decimal"
     },
-    "Count": {
+    "countPerPackage": {
       "type": "integer"
     },
-    "PricePerUnit": {
+    "itemPrice": {
       "type": "decimal"
     },
-    "PricingSource": {
+    "source": {
       "type": "string"
     },
-    "LogDate": {
+    "logDate": {
       "type": "date"
     },
-    "Notes": {
+    "notes": {
       "type": "text"
     }
   }

--- a/src/components/product/volume.json
+++ b/src/components/product/volume.json
@@ -8,22 +8,16 @@
   "attributes": {
     "packageVolume": {
       "type": "decimal",
-      "required": true,
-      "customErrorMessage": {
-        "type": "packageVolume must be a number.",
-        "required": "packageVolume cannot be empty."
-      }
+      "required": true
     },
-    "volumeUnit": {
+    "packageVolumeUnit": {
       "type": "enumeration",
       "enum": ["cubic in", "cubic cm", "cubic ft", "cubic m"],
-      "default": "cubic in",
       "required": true
     },
     "countPerPackage": {
       "type": "integer",
       "required": true,
-      "default": 1,
       "min": 1
     },
     "itemVolumeCBCM": {
@@ -32,7 +26,7 @@
     "countPerCBM": {
       "type": "decimal"
     },
-    "volumeSource": {
+    "source": {
       "type": "string",
       "required": true
     },

--- a/src/components/product/weight.json
+++ b/src/components/product/weight.json
@@ -26,7 +26,7 @@
     "countPerKg": {
       "type": "decimal"
     },
-    "weightSource": {
+    "source": {
       "type": "string",
       "required": true
     },
@@ -35,7 +35,7 @@
       "required": true
     },
     "notes": {
-      "type": "string"
+      "type": "text"
     }
   }
 }

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2024-06-06T16:59:16.833Z"
+    "x-generation-date": "2024-06-06T23:04:41.522Z"
   },
   "x-strapi-config": {
     "path": "/documentation",
@@ -5047,7 +5047,7 @@
                                                         "type": "number",
                                                         "format": "float"
                                                       },
-                                                      "volumeUnit": {
+                                                      "packageVolumeUnit": {
                                                         "type": "string",
                                                         "enum": [
                                                           "cubic in",
@@ -5067,7 +5067,7 @@
                                                         "type": "number",
                                                         "format": "float"
                                                       },
-                                                      "volumeSource": {
+                                                      "source": {
                                                         "type": "string"
                                                       },
                                                       "logDate": {
@@ -5112,7 +5112,7 @@
                                                         "type": "number",
                                                         "format": "float"
                                                       },
-                                                      "weightSource": {
+                                                      "source": {
                                                         "type": "string"
                                                       },
                                                       "logDate": {
@@ -5131,27 +5131,27 @@
                                                     "id": {
                                                       "type": "number"
                                                     },
-                                                    "Items": {
+                                                    "items": {
                                                       "type": "integer"
                                                     },
-                                                    "People": {
+                                                    "people": {
                                                       "type": "integer"
                                                     },
-                                                    "Type": {
+                                                    "type": {
                                                       "type": "string",
                                                       "enum": [
                                                         "DA",
                                                         "SPHERE"
                                                       ]
                                                     },
-                                                    "Months": {
+                                                    "months": {
                                                       "type": "integer"
                                                     },
-                                                    "MonthlyNeedsMetPerUnit": {
+                                                    "monthlyNeedsMetPerUnit": {
                                                       "type": "number",
                                                       "format": "float"
                                                     },
-                                                    "Notes": {
+                                                    "notes": {
                                                       "type": "string"
                                                     }
                                                   }
@@ -5178,25 +5178,25 @@
                                                       "id": {
                                                         "type": "number"
                                                       },
-                                                      "Price": {
+                                                      "packagePrice": {
                                                         "type": "number",
                                                         "format": "float"
                                                       },
-                                                      "Count": {
+                                                      "countPerPackage": {
                                                         "type": "integer"
                                                       },
-                                                      "PricePerUnit": {
+                                                      "itemPrice": {
                                                         "type": "number",
                                                         "format": "float"
                                                       },
-                                                      "PricingSource": {
+                                                      "source": {
                                                         "type": "string"
                                                       },
-                                                      "LogDate": {
+                                                      "logDate": {
                                                         "type": "string",
                                                         "format": "date"
                                                       },
-                                                      "Notes": {
+                                                      "notes": {
                                                         "type": "string"
                                                       }
                                                     }
@@ -6870,7 +6870,7 @@
                                             "type": "number",
                                             "format": "float"
                                           },
-                                          "volumeUnit": {
+                                          "packageVolumeUnit": {
                                             "type": "string",
                                             "enum": [
                                               "cubic in",
@@ -6890,7 +6890,7 @@
                                             "type": "number",
                                             "format": "float"
                                           },
-                                          "volumeSource": {
+                                          "source": {
                                             "type": "string"
                                           },
                                           "logDate": {
@@ -6935,7 +6935,7 @@
                                             "type": "number",
                                             "format": "float"
                                           },
-                                          "weightSource": {
+                                          "source": {
                                             "type": "string"
                                           },
                                           "logDate": {
@@ -6954,27 +6954,27 @@
                                         "id": {
                                           "type": "number"
                                         },
-                                        "Items": {
+                                        "items": {
                                           "type": "integer"
                                         },
-                                        "People": {
+                                        "people": {
                                           "type": "integer"
                                         },
-                                        "Type": {
+                                        "type": {
                                           "type": "string",
                                           "enum": [
                                             "DA",
                                             "SPHERE"
                                           ]
                                         },
-                                        "Months": {
+                                        "months": {
                                           "type": "integer"
                                         },
-                                        "MonthlyNeedsMetPerUnit": {
+                                        "monthlyNeedsMetPerUnit": {
                                           "type": "number",
                                           "format": "float"
                                         },
-                                        "Notes": {
+                                        "notes": {
                                           "type": "string"
                                         }
                                       }
@@ -7001,25 +7001,25 @@
                                           "id": {
                                             "type": "number"
                                           },
-                                          "Price": {
+                                          "packagePrice": {
                                             "type": "number",
                                             "format": "float"
                                           },
-                                          "Count": {
+                                          "countPerPackage": {
                                             "type": "integer"
                                           },
-                                          "PricePerUnit": {
+                                          "itemPrice": {
                                             "type": "number",
                                             "format": "float"
                                           },
-                                          "PricingSource": {
+                                          "source": {
                                             "type": "string"
                                           },
-                                          "LogDate": {
+                                          "logDate": {
                                             "type": "string",
                                             "format": "date"
                                           },
-                                          "Notes": {
+                                          "notes": {
                                             "type": "string"
                                           }
                                         }
@@ -7668,7 +7668,7 @@
                                 "type": "number",
                                 "format": "float"
                               },
-                              "volumeUnit": {
+                              "packageVolumeUnit": {
                                 "type": "string",
                                 "enum": [
                                   "cubic in",
@@ -7688,7 +7688,7 @@
                                 "type": "number",
                                 "format": "float"
                               },
-                              "volumeSource": {
+                              "source": {
                                 "type": "string"
                               },
                               "logDate": {
@@ -7733,7 +7733,7 @@
                                 "type": "number",
                                 "format": "float"
                               },
-                              "weightSource": {
+                              "source": {
                                 "type": "string"
                               },
                               "logDate": {
@@ -7752,27 +7752,27 @@
                             "id": {
                               "type": "number"
                             },
-                            "Items": {
+                            "items": {
                               "type": "integer"
                             },
-                            "People": {
+                            "people": {
                               "type": "integer"
                             },
-                            "Type": {
+                            "type": {
                               "type": "string",
                               "enum": [
                                 "DA",
                                 "SPHERE"
                               ]
                             },
-                            "Months": {
+                            "months": {
                               "type": "integer"
                             },
-                            "MonthlyNeedsMetPerUnit": {
+                            "monthlyNeedsMetPerUnit": {
                               "type": "number",
                               "format": "float"
                             },
-                            "Notes": {
+                            "notes": {
                               "type": "string"
                             }
                           }
@@ -7799,25 +7799,25 @@
                               "id": {
                                 "type": "number"
                               },
-                              "Price": {
+                              "packagePrice": {
                                 "type": "number",
                                 "format": "float"
                               },
-                              "Count": {
+                              "countPerPackage": {
                                 "type": "integer"
                               },
-                              "PricePerUnit": {
+                              "itemPrice": {
                                 "type": "number",
                                 "format": "float"
                               },
-                              "PricingSource": {
+                              "source": {
                                 "type": "string"
                               },
-                              "LogDate": {
+                              "logDate": {
                                 "type": "string",
                                 "format": "date"
                               },
-                              "Notes": {
+                              "notes": {
                                 "type": "string"
                               }
                             }
@@ -8142,7 +8142,7 @@
                                             "type": "number",
                                             "format": "float"
                                           },
-                                          "volumeUnit": {
+                                          "packageVolumeUnit": {
                                             "type": "string",
                                             "enum": [
                                               "cubic in",
@@ -8162,7 +8162,7 @@
                                             "type": "number",
                                             "format": "float"
                                           },
-                                          "volumeSource": {
+                                          "source": {
                                             "type": "string"
                                           },
                                           "logDate": {
@@ -8207,7 +8207,7 @@
                                             "type": "number",
                                             "format": "float"
                                           },
-                                          "weightSource": {
+                                          "source": {
                                             "type": "string"
                                           },
                                           "logDate": {
@@ -8226,27 +8226,27 @@
                                         "id": {
                                           "type": "number"
                                         },
-                                        "Items": {
+                                        "items": {
                                           "type": "integer"
                                         },
-                                        "People": {
+                                        "people": {
                                           "type": "integer"
                                         },
-                                        "Type": {
+                                        "type": {
                                           "type": "string",
                                           "enum": [
                                             "DA",
                                             "SPHERE"
                                           ]
                                         },
-                                        "Months": {
+                                        "months": {
                                           "type": "integer"
                                         },
-                                        "MonthlyNeedsMetPerUnit": {
+                                        "monthlyNeedsMetPerUnit": {
                                           "type": "number",
                                           "format": "float"
                                         },
-                                        "Notes": {
+                                        "notes": {
                                           "type": "string"
                                         }
                                       }
@@ -8273,25 +8273,25 @@
                                           "id": {
                                             "type": "number"
                                           },
-                                          "Price": {
+                                          "packagePrice": {
                                             "type": "number",
                                             "format": "float"
                                           },
-                                          "Count": {
+                                          "countPerPackage": {
                                             "type": "integer"
                                           },
-                                          "PricePerUnit": {
+                                          "itemPrice": {
                                             "type": "number",
                                             "format": "float"
                                           },
-                                          "PricingSource": {
+                                          "source": {
                                             "type": "string"
                                           },
-                                          "LogDate": {
+                                          "logDate": {
                                             "type": "string",
                                             "format": "date"
                                           },
-                                          "Notes": {
+                                          "notes": {
                                             "type": "string"
                                           }
                                         }
@@ -8764,7 +8764,7 @@
             "type": "number",
             "format": "float"
           },
-          "volumeUnit": {
+          "packageVolumeUnit": {
             "type": "string",
             "enum": [
               "cubic in",
@@ -8784,7 +8784,7 @@
             "type": "number",
             "format": "float"
           },
-          "volumeSource": {
+          "source": {
             "type": "string"
           },
           "logDate": {
@@ -8826,7 +8826,7 @@
             "type": "number",
             "format": "float"
           },
-          "weightSource": {
+          "source": {
             "type": "string"
           },
           "logDate": {
@@ -8844,27 +8844,27 @@
           "id": {
             "type": "number"
           },
-          "Items": {
+          "items": {
             "type": "integer"
           },
-          "People": {
+          "people": {
             "type": "integer"
           },
-          "Type": {
+          "type": {
             "type": "string",
             "enum": [
               "DA",
               "SPHERE"
             ]
           },
-          "Months": {
+          "months": {
             "type": "integer"
           },
-          "MonthlyNeedsMetPerUnit": {
+          "monthlyNeedsMetPerUnit": {
             "type": "number",
             "format": "float"
           },
-          "Notes": {
+          "notes": {
             "type": "string"
           }
         }
@@ -8889,25 +8889,25 @@
           "id": {
             "type": "number"
           },
-          "Price": {
+          "packagePrice": {
             "type": "number",
             "format": "float"
           },
-          "Count": {
+          "countPerPackage": {
             "type": "integer"
           },
-          "PricePerUnit": {
+          "itemPrice": {
             "type": "number",
             "format": "float"
           },
-          "PricingSource": {
+          "source": {
             "type": "string"
           },
-          "LogDate": {
+          "logDate": {
             "type": "string",
             "format": "date"
           },
-          "Notes": {
+          "notes": {
             "type": "string"
           }
         }

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2024-06-06T23:04:41.522Z"
+    "x-generation-date": "2024-06-19T20:23:24.035Z"
   },
   "x-strapi-config": {
     "path": "/documentation",
@@ -5147,7 +5147,7 @@
                                                     "months": {
                                                       "type": "integer"
                                                     },
-                                                    "monthlyNeedsMetPerUnit": {
+                                                    "monthlyNeedsMetPerItem": {
                                                       "type": "number",
                                                       "format": "float"
                                                     },
@@ -5182,10 +5182,16 @@
                                                         "type": "number",
                                                         "format": "float"
                                                       },
+                                                      "packagePriceUnit": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                          "USD"
+                                                        ]
+                                                      },
                                                       "countPerPackage": {
                                                         "type": "integer"
                                                       },
-                                                      "itemPrice": {
+                                                      "pricePerItemUSD": {
                                                         "type": "number",
                                                         "format": "float"
                                                       },
@@ -6970,7 +6976,7 @@
                                         "months": {
                                           "type": "integer"
                                         },
-                                        "monthlyNeedsMetPerUnit": {
+                                        "monthlyNeedsMetPerItem": {
                                           "type": "number",
                                           "format": "float"
                                         },
@@ -7005,10 +7011,16 @@
                                             "type": "number",
                                             "format": "float"
                                           },
+                                          "packagePriceUnit": {
+                                            "type": "string",
+                                            "enum": [
+                                              "USD"
+                                            ]
+                                          },
                                           "countPerPackage": {
                                             "type": "integer"
                                           },
-                                          "itemPrice": {
+                                          "pricePerItemUSD": {
                                             "type": "number",
                                             "format": "float"
                                           },
@@ -7768,7 +7780,7 @@
                             "months": {
                               "type": "integer"
                             },
-                            "monthlyNeedsMetPerUnit": {
+                            "monthlyNeedsMetPerItem": {
                               "type": "number",
                               "format": "float"
                             },
@@ -7803,10 +7815,16 @@
                                 "type": "number",
                                 "format": "float"
                               },
+                              "packagePriceUnit": {
+                                "type": "string",
+                                "enum": [
+                                  "USD"
+                                ]
+                              },
                               "countPerPackage": {
                                 "type": "integer"
                               },
-                              "itemPrice": {
+                              "pricePerItemUSD": {
                                 "type": "number",
                                 "format": "float"
                               },
@@ -8242,7 +8260,7 @@
                                         "months": {
                                           "type": "integer"
                                         },
-                                        "monthlyNeedsMetPerUnit": {
+                                        "monthlyNeedsMetPerItem": {
                                           "type": "number",
                                           "format": "float"
                                         },
@@ -8277,10 +8295,16 @@
                                             "type": "number",
                                             "format": "float"
                                           },
+                                          "packagePriceUnit": {
+                                            "type": "string",
+                                            "enum": [
+                                              "USD"
+                                            ]
+                                          },
                                           "countPerPackage": {
                                             "type": "integer"
                                           },
-                                          "itemPrice": {
+                                          "pricePerItemUSD": {
                                             "type": "number",
                                             "format": "float"
                                           },
@@ -8860,7 +8884,7 @@
           "months": {
             "type": "integer"
           },
-          "monthlyNeedsMetPerUnit": {
+          "monthlyNeedsMetPerItem": {
             "type": "number",
             "format": "float"
           },
@@ -8893,10 +8917,16 @@
             "type": "number",
             "format": "float"
           },
+          "packagePriceUnit": {
+            "type": "string",
+            "enum": [
+              "USD"
+            ]
+          },
           "countPerPackage": {
             "type": "integer"
           },
-          "itemPrice": {
+          "pricePerItemUSD": {
             "type": "number",
             "format": "float"
           },

--- a/src/functions/content-types/product/item.ts
+++ b/src/functions/content-types/product/item.ts
@@ -35,9 +35,12 @@ function calculateWeightFields(data) {
 }
 
 function calculateVolumeFields(data) {
-  const { packageVolume, countPerPackage, volumeUnit } = data;
+  const { packageVolume, countPerPackage, packageVolumeUnit } = data;
 
-  const normalizedPagkageVolume = normalizeToCM(packageVolume, volumeUnit);
+  const normalizedPagkageVolume = normalizeToCM(
+    packageVolume,
+    packageVolumeUnit
+  );
 
   let itemVolumeCBCM = normalizedPagkageVolume / countPerPackage;
   let countPerCBM = 1000000 / itemVolumeCBCM;

--- a/types/generated/components.d.ts
+++ b/types/generated/components.d.ts
@@ -59,10 +59,13 @@ export interface ProductValue extends Schema.Component {
   };
   attributes: {
     packagePrice: Attribute.Decimal;
+    packagePriceUnit: Attribute.Enumeration<['USD']> &
+      Attribute.Required &
+      Attribute.DefaultTo<'USD'>;
     countPerPackage: Attribute.Integer;
-    itemPrice: Attribute.Decimal;
-    source: Attribute.String;
-    logDate: Attribute.Date;
+    pricePerItemUSD: Attribute.Decimal;
+    source: Attribute.String & Attribute.Required;
+    logDate: Attribute.Date & Attribute.Required;
     notes: Attribute.Text;
   };
 }

--- a/types/generated/components.d.ts
+++ b/types/generated/components.d.ts
@@ -19,12 +19,12 @@ export interface ProductNeedsMet extends Schema.Component {
     description: '';
   };
   attributes: {
-    Items: Attribute.Integer;
-    People: Attribute.Integer;
-    Type: Attribute.Enumeration<['DA', 'SPHERE']>;
-    Months: Attribute.Integer;
-    MonthlyNeedsMetPerUnit: Attribute.Decimal;
-    Notes: Attribute.Text;
+    items: Attribute.Integer;
+    people: Attribute.Integer;
+    type: Attribute.Enumeration<['DA', 'SPHERE']>;
+    months: Attribute.Integer;
+    monthlyNeedsMetPerUnit: Attribute.Decimal;
+    notes: Attribute.Text;
   };
 }
 
@@ -58,12 +58,12 @@ export interface ProductValue extends Schema.Component {
     description: '';
   };
   attributes: {
-    Price: Attribute.Decimal;
-    Count: Attribute.Integer;
-    PricePerUnit: Attribute.Decimal;
-    PricingSource: Attribute.String;
-    LogDate: Attribute.Date;
-    Notes: Attribute.Text;
+    packagePrice: Attribute.Decimal;
+    countPerPackage: Attribute.Integer;
+    itemPrice: Attribute.Decimal;
+    source: Attribute.String;
+    logDate: Attribute.Date;
+    notes: Attribute.Text;
   };
 }
 
@@ -75,11 +75,10 @@ export interface ProductVolume extends Schema.Component {
   };
   attributes: {
     packageVolume: Attribute.Decimal & Attribute.Required;
-    volumeUnit: Attribute.Enumeration<
+    packageVolumeUnit: Attribute.Enumeration<
       ['cubic in', 'cubic cm', 'cubic ft', 'cubic m']
     > &
-      Attribute.Required &
-      Attribute.DefaultTo<'cubic in'>;
+      Attribute.Required;
     countPerPackage: Attribute.Integer &
       Attribute.Required &
       Attribute.SetMinMax<
@@ -87,11 +86,10 @@ export interface ProductVolume extends Schema.Component {
           min: 1;
         },
         number
-      > &
-      Attribute.DefaultTo<1>;
+      >;
     itemVolumeCBCM: Attribute.Decimal;
     countPerCBM: Attribute.Decimal;
-    volumeSource: Attribute.String & Attribute.Required;
+    source: Attribute.String & Attribute.Required;
     logDate: Attribute.Date & Attribute.Required;
     notes: Attribute.Text;
   };
@@ -117,9 +115,9 @@ export interface ProductWeight extends Schema.Component {
       >;
     itemWeightKg: Attribute.Decimal;
     countPerKg: Attribute.Decimal;
-    weightSource: Attribute.String & Attribute.Required;
+    source: Attribute.String & Attribute.Required;
     logDate: Attribute.Date & Attribute.Required;
-    notes: Attribute.String;
+    notes: Attribute.Text;
   };
 }
 

--- a/types/generated/components.d.ts
+++ b/types/generated/components.d.ts
@@ -23,7 +23,7 @@ export interface ProductNeedsMet extends Schema.Component {
     people: Attribute.Integer;
     type: Attribute.Enumeration<['DA', 'SPHERE']>;
     months: Attribute.Integer;
-    monthlyNeedsMetPerUnit: Attribute.Decimal;
+    monthlyNeedsMetPerItem: Attribute.Decimal;
     notes: Attribute.Text;
   };
 }


### PR DESCRIPTION
Updates the `Product.info` components' field names to be more consistent and/or clarify their intent.
Also removes the default values in the `weight` component.

Closes #63 
