### PR TITLE
Add monthlyNeedsMet and pricePerItemCalculations

### DIFF
--- a/src/functions/content-types/product/item.ts
+++ b/src/functions/content-types/product/item.ts
@@ -2,6 +2,7 @@ export function processProductItem(data) {
   const componentHandlers = {
     weight: calculateWeightFields,
     volume: calculateVolumeFields,
+    needsMet: calculateNeedsMetFields,
   };
 
   for (const [component, handler] of Object.entries(componentHandlers)) {
@@ -79,4 +80,11 @@ function normalizeToCM(volume, unit) {
     default:
       throw new Error(`Unsupported volume unit: ${unit}`);
   }
+}
+
+function calculateNeedsMetFields(data) {
+  const { items, months, people } = data;
+  let monthlyNeedsMetPerItem = (people * months) / items;
+  monthlyNeedsMetPerItem = parseFloat(monthlyNeedsMetPerItem.toFixed(2));
+  return { ...data, monthlyNeedsMetPerItem };
 }

--- a/src/functions/content-types/product/item.ts
+++ b/src/functions/content-types/product/item.ts
@@ -3,6 +3,7 @@ export function processProductItem(data) {
     weight: calculateWeightFields,
     volume: calculateVolumeFields,
     needsMet: calculateNeedsMetFields,
+    value: calculateValueFields,
   };
 
   for (const [component, handler] of Object.entries(componentHandlers)) {
@@ -87,4 +88,13 @@ function calculateNeedsMetFields(data) {
   let monthlyNeedsMetPerItem = (people * months) / items;
   monthlyNeedsMetPerItem = parseFloat(monthlyNeedsMetPerItem.toFixed(2));
   return { ...data, monthlyNeedsMetPerItem };
+}
+
+function calculateValueFields(data) {
+  // Note there is no normalizing of currency units as
+  // currently USD is the only unit available.
+  const { packagePrice, countPerPackage } = data;
+  let pricePerItemUSD = packagePrice / countPerPackage;
+  pricePerItemUSD = parseFloat(pricePerItemUSD.toFixed(2));
+  return { ...data, pricePerItemUSD };
 }

--- a/src/functions/content-types/product/item.ts
+++ b/src/functions/content-types/product/item.ts
@@ -86,7 +86,6 @@ function normalizeToCM(volume, unit) {
 function calculateNeedsMetFields(data) {
   const { items, months, people } = data;
   let monthlyNeedsMetPerItem = (people * months) / items;
-  monthlyNeedsMetPerItem = parseFloat(monthlyNeedsMetPerItem.toFixed(2));
   return { ...data, monthlyNeedsMetPerItem };
 }
 


### PR DESCRIPTION
Adds a calculation for the `monthlyNeedsMetPerItem` field in the `Product.item/needsMet` component
Adds a calculation for the `pricePerItemUSD` field in the `Product.item/value` component. 
Followup to #64 

