### PR TITLE
fix: restore create/update for all content-types via Admin Panel

### DIFF
--- a/src/functions/content-types/index.ts
+++ b/src/functions/content-types/index.ts
@@ -20,6 +20,8 @@ export function processContentType(path, data) {
   const handler = contentTypeHandlers[contentType];
   if (handler) {
     return handler(data);
+  } else {
+    return data;
   }
 }
 


### PR DESCRIPTION
Fixes bug where any Content-type other than `Product.item` created or updated via the Admin Panel was saved with empty field values. Thanks @ll-zerr for finding that! 

Closes #72 