### PR TITLE
refactor `Product.item` controller 

### DIFF
--- a/src/api/product/controllers/item.ts
+++ b/src/api/product/controllers/item.ts
@@ -3,27 +3,21 @@
  */
 
 import { factories } from "@strapi/strapi";
-import { processContentType } from "../../../functions/content-types";
+import { processProductItem } from "../../../functions/content-types/product/item";
 
 export default factories.createCoreController(
   "api::product.item",
 
   ({ strapi }) => ({
     async create(ctx) {
-      ctx.request.body.data = processContentType(
-        ctx.request.path,
-        ctx.request.body.data
-      );
+      ctx.request.body.data = processProductItem(ctx.request.body.data);
 
       const result = await super.create(ctx);
       return result;
     },
 
     async update(ctx) {
-      ctx.request.body.data = processContentType(
-        ctx.request.path,
-        ctx.request.body.data
-      );
+      ctx.request.body.data = processProductItem(ctx.request.body.data);
 
       const result = await super.update(ctx);
       return result;


### PR DESCRIPTION
The `Product.item` controller now calls its calculation function directly. Detecting the content-type (as is done in the Admin panel extension) is not necessary here. We already know the content-type since we're in the specific controller for it.
