### PR TITLE
Refactor: Remove unneeded code

### DIFF
--- a/src/api/product/controllers/item.ts
+++ b/src/api/product/controllers/item.ts
@@ -3,27 +3,21 @@
  */
 
 import { factories } from "@strapi/strapi";
-import { processContentType } from "../../../functions/content-types";
+import { processProductItem } from "../../../functions/content-types/product/item";
 
 export default factories.createCoreController(
   "api::product.item",
 
   ({ strapi }) => ({
     async create(ctx) {
-      ctx.request.body.data = processContentType(
-        ctx.request.path,
-        ctx.request.body.data
-      );
+      ctx.request.body.data = processProductItem(ctx.request.body.data);
 
       const result = await super.create(ctx);
       return result;
     },
 
     async update(ctx) {
-      ctx.request.body.data = processContentType(
-        ctx.request.path,
-        ctx.request.body.data
-      );
+      ctx.request.body.data = processProductItem(ctx.request.body.data);
 
       const result = await super.update(ctx);
       return result;

--- a/src/functions/content-types/index.ts
+++ b/src/functions/content-types/index.ts
@@ -4,15 +4,9 @@ export function processContentType(path, data) {
   /*
    Content-manager paths look like this:
     http://host/admin/content-manager/collection-types/api::product.item/15
-
-   API paths look like this (note the use of the plural version here!)
-    http://host/api/items/15 )
-
-   So need to map both options to the appropriate handler
   */
   const contentTypeHandlers = {
     "product.item": processProductItem,
-    items: processProductItem,
   };
 
   const contentType = detectContentType(path);

--- a/src/functions/content-types/index.ts
+++ b/src/functions/content-types/index.ts
@@ -20,6 +20,8 @@ export function processContentType(path, data) {
   const handler = contentTypeHandlers[contentType];
   if (handler) {
     return handler(data);
+  } else {
+    return data;
   }
 }
 


### PR DESCRIPTION
Forgot to remove the API path option from the `contentTypeHandlers` object. Since we're not testing for that path now, it's not needed there. 
