### PR TITLE
refactor: remove code that is no longer needed

### DIFF
--- a/src/functions/content-types/index.ts
+++ b/src/functions/content-types/index.ts
@@ -4,15 +4,9 @@ export function processContentType(path, data) {
   /*
    Content-manager paths look like this:
     http://host/admin/content-manager/collection-types/api::product.item/15
-
-   API paths look like this (note the use of the plural version here!)
-    http://host/api/items/15 )
-
-   So need to map both options to the appropriate handler
   */
   const contentTypeHandlers = {
     "product.item": processProductItem,
-    items: processProductItem,
   };
 
   const contentType = detectContentType(path);


### PR DESCRIPTION
Forgot to remove the API path option from the `contentTypeHandlers` object. We no longer need to detect requests coming from the API in the `processContentType` function.