### PR TITLE
[CHORE] Trying to explicitly support different OSes and CPU architectures

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,11 @@
 nodeLinker: node-modules
-
 yarnPath: .yarn/releases/yarn-4.4.1.cjs
+supportedArchitectures:
+  os:
+    - darwin
+    - linux
+  cpu:
+    - x64
+    - arm64
+  libc:
+    - glibc


### PR DESCRIPTION
## What changed?

I'm configuring Yarn to explicitly support specific OSes and CPU architectures. This is to hopefully solve an issue one of our devs is experiencing with missing architecture files for the Sharp library.

This is based on the [recommendations from the Sharp library](https://sharp.pixelplumbing.com/install#cross-platform) and the [Yarn docs](https://yarnpkg.com/configuration/yarnrc#supportedArchitectures).

## How can you test this?

1. Switch to this branch.
2. Remove the `node_modules` directory.
3. Run `yarn`.
4. Run `yarn run develop`.
