### PR TITLE
Survey year should be an integer not a string, right?

### DIFF
--- a/src/api/needs-assessment/content-types/survey/schema.json
+++ b/src/api/needs-assessment/content-types/survey/schema.json
@@ -8,12 +8,6 @@
   },
   "options": {},
   "attributes": {
-    "year": {
-      "type": "string",
-      "regex": "^2019|202[0-9]|203[0-9]$",
-      "required": true,
-      "maxLength": 4
-    },
     "quarter": {
       "type": "enumeration",
       "enum": ["Q1", "Q2", "Q3", "Q4"],
@@ -24,6 +18,13 @@
       "relation": "oneToMany",
       "target": "api::needs-assessment.need",
       "mappedBy": "needs_assessment_survey"
+    },
+    "year": {
+      "type": "integer",
+      "default": 2024,
+      "required": true,
+      "min": 2019,
+      "max": 2040
     }
   }
 }

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -692,14 +692,19 @@ export interface ApiNeedsAssessmentSurvey extends Struct.CollectionTypeSchema {
     draftAndPublish: false;
   };
   attributes: {
-    year: Schema.Attribute.String &
-      Schema.Attribute.Required &
-      Schema.Attribute.SetMinMaxLength<{
-        maxLength: 4;
-      }>;
     quarter: Schema.Attribute.Enumeration<["Q1", "Q2", "Q3", "Q4"]> &
       Schema.Attribute.Required;
     needs: Schema.Attribute.Relation<"oneToMany", "api::needs-assessment.need">;
+    year: Schema.Attribute.Integer &
+      Schema.Attribute.Required &
+      Schema.Attribute.SetMinMax<
+        {
+          min: 2019;
+          max: 2040;
+        },
+        number
+      > &
+      Schema.Attribute.DefaultTo<2024>;
     createdAt: Schema.Attribute.DateTime;
     updatedAt: Schema.Attribute.DateTime;
     publishedAt: Schema.Attribute.DateTime;


### PR DESCRIPTION
Just because this kind of migration is difficult after the fact.