### PR TITLE
docs: remove Open Collective Foundation link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -2,7 +2,6 @@
 
 github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
 patreon: # Replace with a single Patreon username
-open_collective: distribute-aid-usa
 ko_fi: # Replace with a single Ko-fi username
 tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
 community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry


### PR DESCRIPTION
## What changed?

Removed link to Open Collective Foundation in `FUNDING.yml` per https://github.com/distributeaid/aggregated-public-information/issues/180.

## How can you test this?
Go to [the repo](https://github.com/distributeaid/aggregated-public-information) and make sure the sponsorship information looks correct.