### PR TITLE
fix: remove @ts-expect-error directives causing ci/cd error

### DIFF
--- a/src/api/group/controllers/group.ts
+++ b/src/api/group/controllers/group.ts
@@ -10,7 +10,6 @@ export default factories.createCoreController(
 
   ({ strapi: _strapi }) => ({
     async create(ctx) {
-      // @ts-expect-error It thinks ctx.request.body doesn't exist
       ctx.request.body.data = processGroup(ctx.request.body.data);
 
       const result = await super.create(ctx);
@@ -18,7 +17,6 @@ export default factories.createCoreController(
     },
 
     async update(ctx) {
-      // @ts-expect-error It thinks ctx.request.body doesn't exist
       ctx.request.body.data = processGroup(ctx.request.body.data);
 
       const result = await super.update(ctx);

--- a/src/api/product/controllers/item.ts
+++ b/src/api/product/controllers/item.ts
@@ -9,7 +9,6 @@ export default factories.createCoreController(
   "api::product.item",
   ({ strapi: _strapi }) => ({
     async create(ctx) {
-      // @ts-expect-error It thinks ctx.request.body doesn't exist
       ctx.request.body.data = processProductItem(ctx.request.body.data);
 
       const result = await super.create(ctx);
@@ -17,7 +16,6 @@ export default factories.createCoreController(
     },
 
     async update(ctx) {
-      // @ts-expect-error It thinks ctx.request.body doesn't exist
       ctx.request.body.data = processProductItem(ctx.request.body.data);
 
       const result = await super.update(ctx);

--- a/src/api/reporting/controllers/cargo.ts
+++ b/src/api/reporting/controllers/cargo.ts
@@ -9,7 +9,6 @@ export default factories.createCoreController(
   "api::reporting.cargo",
   ({ strapi: _strapi }) => ({
     async create(ctx) {
-      // @ts-expect-error It thinks ctx.request.body doesn't exist
       ctx.request.body.data = processReportingCargo(ctx.request.body.data);
 
       const result = await super.create(ctx);
@@ -17,7 +16,6 @@ export default factories.createCoreController(
     },
 
     async update(ctx) {
-      // @ts-expect-error It thinks ctx.request.body doesn't exist
       ctx.request.body.data = processReportingCargo(ctx.request.body.data);
 
       const result = await super.update(ctx);


### PR DESCRIPTION
## What changed?

Fix for https://github.com/distributeaid/aggregated-public-information/issues/182

## How can you test this?
Locally, run `yarn tsc` (or `yarn run check:types`) and make sure there are no errors. On GitHub, open a PR and ensure the pipeline continues past the `Run type check` step.