### PR TITLE
draft: add uniqueness check beforeCreate hook for needs model

### DIFF
--- a/src/api/needs-assessment/content-types/need/lifecycles.ts
+++ b/src/api/needs-assessment/content-types/need/lifecycles.ts
@@ -1,7 +1,9 @@
 import { errors } from "@strapi/utils";
 export default {
-  beforeCreate(event) {
+  beforeCreate(event: any) {
     console.log("beforeCreate lifecycles");
-    throw new errors.ApplicationError("oh no");
+    const { populate, data } = event.params;
+    // console.log(JSON.stringify({ populate, data }, undefined, 2));
+    // throw new errors.ApplicationError("oh no");
   },
 };

--- a/src/api/needs-assessment/content-types/need/lifecycles.ts
+++ b/src/api/needs-assessment/content-types/need/lifecycles.ts
@@ -1,0 +1,7 @@
+import { errors } from "@strapi/utils";
+export default {
+  beforeCreate(event) {
+    console.log("beforeCreate lifecycles");
+    throw new errors.ApplicationError("oh no");
+  },
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,8 @@ export default {
    * run jobs, or perform some special logic.
    */
   async bootstrap({ strapi }: { strapi: Core.Strapi }) {
+    console.log("bootstrap");
     await createPublicApiPermissions(strapi);
-    registerDbLifecycleHooks(strapi);
+    await registerDbLifecycleHooks(strapi);
   },
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import type { Core } from "@strapi/strapi";
 import { createPublicApiPermissions } from "./createPublicApiPermissions";
+import registerDbLifecycleHooks from "./registerDbLifecycleHooks";
 
 export default {
   /**
@@ -19,5 +20,6 @@ export default {
    */
   async bootstrap({ strapi }: { strapi: Core.Strapi }) {
     await createPublicApiPermissions(strapi);
+    registerDbLifecycleHooks(strapi);
   },
 };

--- a/src/registerDbLifecycleHooks.ts
+++ b/src/registerDbLifecycleHooks.ts
@@ -1,0 +1,34 @@
+import { Core } from "@strapi/strapi";
+import { errors } from "@strapi/utils";
+
+export default function registerDbLifecycleHooks(strapi: Core.Strapi) {
+  strapi.db.lifecycles.subscribe({
+    models: ["need"],
+    async beforeCreate(event) {
+      const { data } = event.params;
+      const preexistingNeed = await strapi.db.connection
+        .from("needs")
+        .join("needs_item_lnk", "needs.id", "=", "needs_item_lnk.need_id")
+        .join("needs_region_lnk", "needs.id", "=", "needs_region_lnk.need_id")
+        .join(
+          "needs_subregion_lnk",
+          "needs.id",
+          "=",
+          "needs_subregion_lnk.need_id",
+        )
+        .join("needs_survey_lnk", "needs.id", "=", "needs_survey_lnk.need_id")
+        .where((builder) => {
+          builder
+            .where("needs_item_lnk.item_id", data.item_id)
+            .andWhere("needs_region_lnk.region_id", data.region_id)
+            .andWhere("needs_subregion_lnk.subregion_id", data.subregion_id)
+            .andWhere("needs_survey_lnk.survey_id", data.survey_id)
+            .andWhere("needs.need", data.need);
+        })
+        .first("needs.id");
+      if (preexistingNeed || preexistingNeed !== undefined) {
+        throw new errors.ApplicationError("Duplicate Need");
+      }
+    },
+  });
+}

--- a/src/registerDbLifecycleHooks.ts
+++ b/src/registerDbLifecycleHooks.ts
@@ -1,36 +1,54 @@
 import { Core } from "@strapi/strapi";
 import { errors } from "@strapi/utils";
 
-export default function registerDbLifecycleHooks(strapi: Core.Strapi) {
-  console.log("registering lifecycle hooks");
+export default async function registerDbLifecycleHooks(strapi: Core.Strapi) {
   strapi.db.lifecycles.subscribe({
-    models: [],
     async beforeCreate(event) {
-      console.log("beforeCreate index");
-      const { data } = event.params;
-      const preexistingNeed = await strapi.db.connection
-        .from("needs")
-        .join("needs_item_lnk", "needs.id", "=", "needs_item_lnk.need_id")
-        .join("needs_region_lnk", "needs.id", "=", "needs_region_lnk.need_id")
-        .join(
-          "needs_subregion_lnk",
-          "needs.id",
-          "=",
-          "needs_subregion_lnk.need_id",
-        )
-        .join("needs_survey_lnk", "needs.id", "=", "needs_survey_lnk.need_id")
-        .where((builder) => {
-          builder
-            .where("needs_item_lnk.item_id", data.item_id)
-            .andWhere("needs_region_lnk.region_id", data.region_id)
-            .andWhere("needs_subregion_lnk.subregion_id", data.subregion_id)
-            .andWhere("needs_survey_lnk.survey_id", data.survey_id)
-            .andWhere("needs.need", data.need);
-        })
-        .first("needs.id");
-      if (preexistingNeed || preexistingNeed !== undefined) {
-        throw new errors.ApplicationError("Duplicate Need");
+      if (event.model.tableName === "needs") {
+        console.log("beforeCreate index");
+        // console.log(JSON.stringify(event.model, undefined, 2));
+        // console.log(JSON.stringify(event.params, undefined, 2));
+        const { data } = event.params;
+        const trx = await strapi.db.connection.transaction();
+        const preexistingNeed = await trx
+          .select("id")
+          .from("needs")
+          .join("needs_item_lnk", "needs.id", "=", "needs_item_lnk.need_id")
+          .join("needs_region_lnk", "needs.id", "=", "needs_region_lnk.need_id")
+          .join(
+            "needs_subregion_lnk",
+            "needs.id",
+            "=",
+            "needs_subregion_lnk.need_id",
+          )
+          .join("needs_survey_lnk", "needs.id", "=", "needs_survey_lnk.need_id")
+          .where((builder) => {
+            builder
+              .whereIn(
+                "needs_item_lnk.item_id",
+                data.item.connect.map(({ id }) => id),
+              )
+              .whereIn(
+                "needs_region_lnk.region_id",
+                data.region.connect.map(({ id }) => id),
+              )
+              .whereIn(
+                "needs_subregion_lnk.subregion_id",
+                data.subregion.connect.map(({ id }) => id),
+              )
+              .whereIn(
+                "needs_survey_lnk.survey_id",
+                data.survey.connect.map(({ id }) => id),
+              )
+              .andWhere("needs.need", data.need);
+          })
+          .first();
+        console.log(`preexistingNeed: ${JSON.stringify(preexistingNeed)}`);
+        if (preexistingNeed || preexistingNeed !== undefined) {
+          throw new errors.ApplicationError("Duplicate Need");
+        }
       }
     },
   });
+  console.log("registered lifecycle hooks");
 }

--- a/src/registerDbLifecycleHooks.ts
+++ b/src/registerDbLifecycleHooks.ts
@@ -2,9 +2,11 @@ import { Core } from "@strapi/strapi";
 import { errors } from "@strapi/utils";
 
 export default function registerDbLifecycleHooks(strapi: Core.Strapi) {
+  console.log("registering lifecycle hooks");
   strapi.db.lifecycles.subscribe({
-    models: ["need"],
+    models: [],
     async beforeCreate(event) {
+      console.log("beforeCreate index");
       const { data } = event.params;
       const preexistingNeed = await strapi.db.connection
         .from("needs")

--- a/types/generated/components.d.ts
+++ b/types/generated/components.d.ts
@@ -1,100 +1,29 @@
-import type { Struct, Schema } from "@strapi/strapi";
+import type { Schema, Struct } from "@strapi/strapi";
 
-export interface TimeDuration extends Struct.ComponentSchema {
-  collectionName: "components_time_durations";
+export interface GeoLocation extends Struct.ComponentSchema {
+  collectionName: "components_geo_locations";
   info: {
-    displayName: "Duration";
-    icon: "clock";
+    displayName: "Location";
+    icon: "pinMap";
   };
   attributes: {
-    Start: Schema.Attribute.DateTime & Schema.Attribute.Required;
-    End: Schema.Attribute.DateTime;
+    Country: Schema.Attribute.Relation<"oneToOne", "api::geo.country">;
+    Name: Schema.Attribute.String & Schema.Attribute.Required;
   };
 }
 
-export interface TeamRole extends Struct.ComponentSchema {
-  collectionName: "components_team_roles";
+export interface ProductNeedsMet extends Struct.ComponentSchema {
+  collectionName: "components_product_needs_mets";
   info: {
-    displayName: "Role";
-    icon: "handHeart";
-    description: "";
+    displayName: "Needs Met";
   };
   attributes: {
-    Title: Schema.Attribute.String & Schema.Attribute.Required;
-    Type: Schema.Attribute.String;
-    Location: Schema.Attribute.Component<"geo.location", false>;
-    Duration: Schema.Attribute.Component<"time.duration", false>;
-  };
-}
-
-export interface ProductWeight extends Struct.ComponentSchema {
-  collectionName: "components_product_weights";
-  info: {
-    displayName: "Weight";
-  };
-  attributes: {
-    packageWeight: Schema.Attribute.Decimal & Schema.Attribute.Required;
-    packageWeightUnit: Schema.Attribute.Enumeration<["lb", "oz", "g", "kg"]> &
-      Schema.Attribute.Required;
-    countPerPackage: Schema.Attribute.Integer &
-      Schema.Attribute.Required &
-      Schema.Attribute.SetMinMax<
-        {
-          min: 1;
-        },
-        number
-      >;
-    itemWeightKg: Schema.Attribute.Decimal;
-    countPerKg: Schema.Attribute.Decimal;
-    source: Schema.Attribute.String & Schema.Attribute.Required;
-    logDate: Schema.Attribute.Date & Schema.Attribute.Required;
+    items: Schema.Attribute.Integer;
+    monthlyNeedsMetPerItem: Schema.Attribute.Decimal;
+    months: Schema.Attribute.Integer;
     notes: Schema.Attribute.Text;
-  };
-}
-
-export interface ProductVolume extends Struct.ComponentSchema {
-  collectionName: "components_product_volumes";
-  info: {
-    displayName: "Volume";
-    description: "";
-  };
-  attributes: {
-    packageVolume: Schema.Attribute.Decimal & Schema.Attribute.Required;
-    packageVolumeUnit: Schema.Attribute.Enumeration<
-      ["cubic in", "cubic cm", "cubic ft", "cubic m"]
-    > &
-      Schema.Attribute.Required;
-    countPerPackage: Schema.Attribute.Integer &
-      Schema.Attribute.Required &
-      Schema.Attribute.SetMinMax<
-        {
-          min: 1;
-        },
-        number
-      >;
-    itemVolumeCBCM: Schema.Attribute.Decimal;
-    countPerCBM: Schema.Attribute.Decimal;
-    source: Schema.Attribute.String & Schema.Attribute.Required;
-    logDate: Schema.Attribute.Date & Schema.Attribute.Required;
-    notes: Schema.Attribute.Text;
-  };
-}
-
-export interface ProductValue extends Struct.ComponentSchema {
-  collectionName: "components_product_values";
-  info: {
-    displayName: "Value";
-  };
-  attributes: {
-    packagePrice: Schema.Attribute.Decimal;
-    packagePriceUnit: Schema.Attribute.Enumeration<["USD"]> &
-      Schema.Attribute.Required &
-      Schema.Attribute.DefaultTo<"USD">;
-    countPerPackage: Schema.Attribute.Integer;
-    pricePerItemUSD: Schema.Attribute.Decimal;
-    source: Schema.Attribute.String & Schema.Attribute.Required;
-    logDate: Schema.Attribute.Date & Schema.Attribute.Required;
-    notes: Schema.Attribute.Text;
+    people: Schema.Attribute.Integer;
+    type: Schema.Attribute.Enumeration<["DA", "SPHERE"]>;
   };
 }
 
@@ -111,8 +40,8 @@ export interface ProductSecondHand extends Struct.ComponentSchema {
       Schema.Attribute.Required &
       Schema.Attribute.SetMinMax<
         {
-          min: 0;
           max: 100;
+          min: 0;
         },
         number
       > &
@@ -120,44 +49,115 @@ export interface ProductSecondHand extends Struct.ComponentSchema {
   };
 }
 
-export interface ProductNeedsMet extends Struct.ComponentSchema {
-  collectionName: "components_product_needs_mets";
+export interface ProductValue extends Struct.ComponentSchema {
+  collectionName: "components_product_values";
   info: {
-    displayName: "Needs Met";
+    displayName: "Value";
   };
   attributes: {
-    items: Schema.Attribute.Integer;
-    people: Schema.Attribute.Integer;
-    type: Schema.Attribute.Enumeration<["DA", "SPHERE"]>;
-    months: Schema.Attribute.Integer;
-    monthlyNeedsMetPerItem: Schema.Attribute.Decimal;
+    countPerPackage: Schema.Attribute.Integer;
+    logDate: Schema.Attribute.Date & Schema.Attribute.Required;
     notes: Schema.Attribute.Text;
+    packagePrice: Schema.Attribute.Decimal;
+    packagePriceUnit: Schema.Attribute.Enumeration<["USD"]> &
+      Schema.Attribute.Required &
+      Schema.Attribute.DefaultTo<"USD">;
+    pricePerItemUSD: Schema.Attribute.Decimal;
+    source: Schema.Attribute.String & Schema.Attribute.Required;
   };
 }
 
-export interface GeoLocation extends Struct.ComponentSchema {
-  collectionName: "components_geo_locations";
+export interface ProductVolume extends Struct.ComponentSchema {
+  collectionName: "components_product_volumes";
   info: {
-    displayName: "Location";
-    icon: "pinMap";
+    description: "";
+    displayName: "Volume";
   };
   attributes: {
-    Name: Schema.Attribute.String & Schema.Attribute.Required;
-    Country: Schema.Attribute.Relation<"oneToOne", "api::geo.country">;
+    countPerCBM: Schema.Attribute.Decimal;
+    countPerPackage: Schema.Attribute.Integer &
+      Schema.Attribute.Required &
+      Schema.Attribute.SetMinMax<
+        {
+          min: 1;
+        },
+        number
+      >;
+    itemVolumeCBCM: Schema.Attribute.Decimal;
+    logDate: Schema.Attribute.Date & Schema.Attribute.Required;
+    notes: Schema.Attribute.Text;
+    packageVolume: Schema.Attribute.Decimal & Schema.Attribute.Required;
+    packageVolumeUnit: Schema.Attribute.Enumeration<
+      ["cubic in", "cubic cm", "cubic ft", "cubic m"]
+    > &
+      Schema.Attribute.Required;
+    source: Schema.Attribute.String & Schema.Attribute.Required;
+  };
+}
+
+export interface ProductWeight extends Struct.ComponentSchema {
+  collectionName: "components_product_weights";
+  info: {
+    displayName: "Weight";
+  };
+  attributes: {
+    countPerKg: Schema.Attribute.Decimal;
+    countPerPackage: Schema.Attribute.Integer &
+      Schema.Attribute.Required &
+      Schema.Attribute.SetMinMax<
+        {
+          min: 1;
+        },
+        number
+      >;
+    itemWeightKg: Schema.Attribute.Decimal;
+    logDate: Schema.Attribute.Date & Schema.Attribute.Required;
+    notes: Schema.Attribute.Text;
+    packageWeight: Schema.Attribute.Decimal & Schema.Attribute.Required;
+    packageWeightUnit: Schema.Attribute.Enumeration<["lb", "oz", "g", "kg"]> &
+      Schema.Attribute.Required;
+    source: Schema.Attribute.String & Schema.Attribute.Required;
+  };
+}
+
+export interface TeamRole extends Struct.ComponentSchema {
+  collectionName: "components_team_roles";
+  info: {
+    description: "";
+    displayName: "Role";
+    icon: "handHeart";
+  };
+  attributes: {
+    Duration: Schema.Attribute.Component<"time.duration", false>;
+    Location: Schema.Attribute.Component<"geo.location", false>;
+    Title: Schema.Attribute.String & Schema.Attribute.Required;
+    Type: Schema.Attribute.String;
+  };
+}
+
+export interface TimeDuration extends Struct.ComponentSchema {
+  collectionName: "components_time_durations";
+  info: {
+    displayName: "Duration";
+    icon: "clock";
+  };
+  attributes: {
+    End: Schema.Attribute.DateTime;
+    Start: Schema.Attribute.DateTime & Schema.Attribute.Required;
   };
 }
 
 declare module "@strapi/strapi" {
   export module Public {
     export interface ComponentSchemas {
-      "time.duration": TimeDuration;
-      "team.role": TeamRole;
-      "product.weight": ProductWeight;
-      "product.volume": ProductVolume;
-      "product.value": ProductValue;
-      "product.second-hand": ProductSecondHand;
-      "product.needs-met": ProductNeedsMet;
       "geo.location": GeoLocation;
+      "product.needs-met": ProductNeedsMet;
+      "product.second-hand": ProductSecondHand;
+      "product.value": ProductValue;
+      "product.volume": ProductVolume;
+      "product.weight": ProductWeight;
+      "team.role": TeamRole;
+      "time.duration": TimeDuration;
     }
   }
 }

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -1,12 +1,13 @@
-import type { Struct, Schema } from "@strapi/strapi";
+import type { Schema, Struct } from "@strapi/strapi";
 
-export interface PluginUploadFile extends Struct.CollectionTypeSchema {
-  collectionName: "files";
+export interface AdminApiToken extends Struct.CollectionTypeSchema {
+  collectionName: "strapi_api_tokens";
   info: {
-    singularName: "file";
-    pluralName: "files";
-    displayName: "File";
     description: "";
+    displayName: "Api Token";
+    name: "Api Token";
+    pluralName: "api-tokens";
+    singularName: "api-token";
   };
   options: {
     draftAndPublish: false;
@@ -20,969 +21,96 @@ export interface PluginUploadFile extends Struct.CollectionTypeSchema {
     };
   };
   attributes: {
-    name: Schema.Attribute.String & Schema.Attribute.Required;
-    alternativeText: Schema.Attribute.String;
-    caption: Schema.Attribute.String;
-    width: Schema.Attribute.Integer;
-    height: Schema.Attribute.Integer;
-    formats: Schema.Attribute.JSON;
-    hash: Schema.Attribute.String & Schema.Attribute.Required;
-    ext: Schema.Attribute.String;
-    mime: Schema.Attribute.String & Schema.Attribute.Required;
-    size: Schema.Attribute.Decimal & Schema.Attribute.Required;
-    url: Schema.Attribute.String & Schema.Attribute.Required;
-    previewUrl: Schema.Attribute.String;
-    provider: Schema.Attribute.String & Schema.Attribute.Required;
-    provider_metadata: Schema.Attribute.JSON;
-    related: Schema.Attribute.Relation<"morphToMany">;
-    folder: Schema.Attribute.Relation<"manyToOne", "plugin::upload.folder"> &
-      Schema.Attribute.Private;
-    folderPath: Schema.Attribute.String &
-      Schema.Attribute.Required &
-      Schema.Attribute.Private &
-      Schema.Attribute.SetMinMaxLength<{
-        minLength: 1;
-      }>;
-    createdAt: Schema.Attribute.DateTime;
-    updatedAt: Schema.Attribute.DateTime;
-    publishedAt: Schema.Attribute.DateTime;
-    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
-      Schema.Attribute.Private;
-    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
-      Schema.Attribute.Private;
-    locale: Schema.Attribute.String;
-  };
-}
-
-export interface PluginUploadFolder extends Struct.CollectionTypeSchema {
-  collectionName: "upload_folders";
-  info: {
-    singularName: "folder";
-    pluralName: "folders";
-    displayName: "Folder";
-  };
-  options: {
-    draftAndPublish: false;
-  };
-  pluginOptions: {
-    "content-manager": {
-      visible: false;
-    };
-    "content-type-builder": {
-      visible: false;
-    };
-  };
-  attributes: {
-    name: Schema.Attribute.String &
-      Schema.Attribute.Required &
-      Schema.Attribute.SetMinMaxLength<{
-        minLength: 1;
-      }>;
-    pathId: Schema.Attribute.Integer &
-      Schema.Attribute.Required &
-      Schema.Attribute.Unique;
-    parent: Schema.Attribute.Relation<"manyToOne", "plugin::upload.folder">;
-    children: Schema.Attribute.Relation<"oneToMany", "plugin::upload.folder">;
-    files: Schema.Attribute.Relation<"oneToMany", "plugin::upload.file">;
-    path: Schema.Attribute.String &
+    accessKey: Schema.Attribute.String &
       Schema.Attribute.Required &
       Schema.Attribute.SetMinMaxLength<{
         minLength: 1;
       }>;
     createdAt: Schema.Attribute.DateTime;
-    updatedAt: Schema.Attribute.DateTime;
-    publishedAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
       Schema.Attribute.Private;
-    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
-      Schema.Attribute.Private;
-    locale: Schema.Attribute.String;
-  };
-}
-
-export interface PluginI18NLocale extends Struct.CollectionTypeSchema {
-  collectionName: "i18n_locale";
-  info: {
-    singularName: "locale";
-    pluralName: "locales";
-    collectionName: "locales";
-    displayName: "Locale";
-    description: "";
-  };
-  options: {
-    draftAndPublish: false;
-  };
-  pluginOptions: {
-    "content-manager": {
-      visible: false;
-    };
-    "content-type-builder": {
-      visible: false;
-    };
-  };
-  attributes: {
-    name: Schema.Attribute.String &
-      Schema.Attribute.SetMinMax<
-        {
-          min: 1;
-          max: 50;
-        },
-        number
-      >;
-    code: Schema.Attribute.String & Schema.Attribute.Unique;
-    createdAt: Schema.Attribute.DateTime;
-    updatedAt: Schema.Attribute.DateTime;
-    publishedAt: Schema.Attribute.DateTime;
-    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
-      Schema.Attribute.Private;
-    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
-      Schema.Attribute.Private;
-    locale: Schema.Attribute.String;
-  };
-}
-
-export interface PluginContentReleasesRelease
-  extends Struct.CollectionTypeSchema {
-  collectionName: "strapi_releases";
-  info: {
-    singularName: "release";
-    pluralName: "releases";
-    displayName: "Release";
-  };
-  options: {
-    draftAndPublish: false;
-  };
-  pluginOptions: {
-    "content-manager": {
-      visible: false;
-    };
-    "content-type-builder": {
-      visible: false;
-    };
-  };
-  attributes: {
-    name: Schema.Attribute.String & Schema.Attribute.Required;
-    releasedAt: Schema.Attribute.DateTime;
-    scheduledAt: Schema.Attribute.DateTime;
-    timezone: Schema.Attribute.String;
-    status: Schema.Attribute.Enumeration<
-      ["ready", "blocked", "failed", "done", "empty"]
-    > &
-      Schema.Attribute.Required;
-    actions: Schema.Attribute.Relation<
-      "oneToMany",
-      "plugin::content-releases.release-action"
-    >;
-    createdAt: Schema.Attribute.DateTime;
-    updatedAt: Schema.Attribute.DateTime;
-    publishedAt: Schema.Attribute.DateTime;
-    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
-      Schema.Attribute.Private;
-    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
-      Schema.Attribute.Private;
-    locale: Schema.Attribute.String;
-  };
-}
-
-export interface PluginContentReleasesReleaseAction
-  extends Struct.CollectionTypeSchema {
-  collectionName: "strapi_release_actions";
-  info: {
-    singularName: "release-action";
-    pluralName: "release-actions";
-    displayName: "Release Action";
-  };
-  options: {
-    draftAndPublish: false;
-  };
-  pluginOptions: {
-    "content-manager": {
-      visible: false;
-    };
-    "content-type-builder": {
-      visible: false;
-    };
-  };
-  attributes: {
-    type: Schema.Attribute.Enumeration<["publish", "unpublish"]> &
-      Schema.Attribute.Required;
-    contentType: Schema.Attribute.String & Schema.Attribute.Required;
-    entryDocumentId: Schema.Attribute.String;
-    locale: Schema.Attribute.String;
-    release: Schema.Attribute.Relation<
-      "manyToOne",
-      "plugin::content-releases.release"
-    >;
-    isEntryValid: Schema.Attribute.Boolean;
-    createdAt: Schema.Attribute.DateTime;
-    updatedAt: Schema.Attribute.DateTime;
-    publishedAt: Schema.Attribute.DateTime;
-    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
-      Schema.Attribute.Private;
-    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
-      Schema.Attribute.Private;
-  };
-}
-
-export interface PluginReviewWorkflowsWorkflow
-  extends Struct.CollectionTypeSchema {
-  collectionName: "strapi_workflows";
-  info: {
-    name: "Workflow";
-    description: "";
-    singularName: "workflow";
-    pluralName: "workflows";
-    displayName: "Workflow";
-  };
-  options: {
-    draftAndPublish: false;
-  };
-  pluginOptions: {
-    "content-manager": {
-      visible: false;
-    };
-    "content-type-builder": {
-      visible: false;
-    };
-  };
-  attributes: {
-    name: Schema.Attribute.String &
-      Schema.Attribute.Required &
-      Schema.Attribute.Unique;
-    stages: Schema.Attribute.Relation<
-      "oneToMany",
-      "plugin::review-workflows.workflow-stage"
-    >;
-    contentTypes: Schema.Attribute.JSON &
-      Schema.Attribute.Required &
-      Schema.Attribute.DefaultTo<"[]">;
-    createdAt: Schema.Attribute.DateTime;
-    updatedAt: Schema.Attribute.DateTime;
-    publishedAt: Schema.Attribute.DateTime;
-    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
-      Schema.Attribute.Private;
-    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
-      Schema.Attribute.Private;
-    locale: Schema.Attribute.String;
-  };
-}
-
-export interface PluginReviewWorkflowsWorkflowStage
-  extends Struct.CollectionTypeSchema {
-  collectionName: "strapi_workflows_stages";
-  info: {
-    name: "Workflow Stage";
-    description: "";
-    singularName: "workflow-stage";
-    pluralName: "workflow-stages";
-    displayName: "Stages";
-  };
-  options: {
-    version: "1.1.0";
-    draftAndPublish: false;
-  };
-  pluginOptions: {
-    "content-manager": {
-      visible: false;
-    };
-    "content-type-builder": {
-      visible: false;
-    };
-  };
-  attributes: {
-    name: Schema.Attribute.String;
-    color: Schema.Attribute.String & Schema.Attribute.DefaultTo<"#4945FF">;
-    workflow: Schema.Attribute.Relation<
-      "manyToOne",
-      "plugin::review-workflows.workflow"
-    >;
-    permissions: Schema.Attribute.Relation<"manyToMany", "admin::permission">;
-    createdAt: Schema.Attribute.DateTime;
-    updatedAt: Schema.Attribute.DateTime;
-    publishedAt: Schema.Attribute.DateTime;
-    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
-      Schema.Attribute.Private;
-    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
-      Schema.Attribute.Private;
-    locale: Schema.Attribute.String;
-  };
-}
-
-export interface PluginSlugifySlug extends Struct.CollectionTypeSchema {
-  collectionName: "slugs";
-  info: {
-    singularName: "slug";
-    pluralName: "slugs";
-    displayName: "slug";
-  };
-  options: {
-    draftAndPublish: false;
-    comment: "";
-  };
-  pluginOptions: {
-    "content-manager": {
-      visible: false;
-    };
-    "content-type-builder": {
-      visible: false;
-    };
-  };
-  attributes: {
-    slug: Schema.Attribute.Text;
-    count: Schema.Attribute.Integer;
-    createdAt: Schema.Attribute.DateTime;
-    updatedAt: Schema.Attribute.DateTime;
-    publishedAt: Schema.Attribute.DateTime;
-    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
-      Schema.Attribute.Private;
-    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
-      Schema.Attribute.Private;
-    locale: Schema.Attribute.String;
-  };
-}
-
-export interface PluginUsersPermissionsPermission
-  extends Struct.CollectionTypeSchema {
-  collectionName: "up_permissions";
-  info: {
-    name: "permission";
-    description: "";
-    singularName: "permission";
-    pluralName: "permissions";
-    displayName: "Permission";
-  };
-  options: {
-    draftAndPublish: false;
-  };
-  pluginOptions: {
-    "content-manager": {
-      visible: false;
-    };
-    "content-type-builder": {
-      visible: false;
-    };
-  };
-  attributes: {
-    action: Schema.Attribute.String & Schema.Attribute.Required;
-    role: Schema.Attribute.Relation<
-      "manyToOne",
-      "plugin::users-permissions.role"
-    >;
-    createdAt: Schema.Attribute.DateTime;
-    updatedAt: Schema.Attribute.DateTime;
-    publishedAt: Schema.Attribute.DateTime;
-    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
-      Schema.Attribute.Private;
-    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
-      Schema.Attribute.Private;
-    locale: Schema.Attribute.String;
-  };
-}
-
-export interface PluginUsersPermissionsRole
-  extends Struct.CollectionTypeSchema {
-  collectionName: "up_roles";
-  info: {
-    name: "role";
-    description: "";
-    singularName: "role";
-    pluralName: "roles";
-    displayName: "Role";
-  };
-  options: {
-    draftAndPublish: false;
-  };
-  pluginOptions: {
-    "content-manager": {
-      visible: false;
-    };
-    "content-type-builder": {
-      visible: false;
-    };
-  };
-  attributes: {
-    name: Schema.Attribute.String &
-      Schema.Attribute.Required &
+    description: Schema.Attribute.String &
       Schema.Attribute.SetMinMaxLength<{
-        minLength: 3;
+        minLength: 1;
+      }> &
+      Schema.Attribute.DefaultTo<"">;
+    expiresAt: Schema.Attribute.DateTime;
+    lastUsedAt: Schema.Attribute.DateTime;
+    lifespan: Schema.Attribute.BigInteger;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<"oneToMany", "admin::api-token"> &
+      Schema.Attribute.Private;
+    name: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.Unique &
+      Schema.Attribute.SetMinMaxLength<{
+        minLength: 1;
       }>;
-    description: Schema.Attribute.String;
-    type: Schema.Attribute.String & Schema.Attribute.Unique;
     permissions: Schema.Attribute.Relation<
       "oneToMany",
-      "plugin::users-permissions.permission"
+      "admin::api-token-permission"
     >;
-    users: Schema.Attribute.Relation<
+    publishedAt: Schema.Attribute.DateTime;
+    type: Schema.Attribute.Enumeration<["read-only", "full-access", "custom"]> &
+      Schema.Attribute.Required &
+      Schema.Attribute.DefaultTo<"read-only">;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+  };
+}
+
+export interface AdminApiTokenPermission extends Struct.CollectionTypeSchema {
+  collectionName: "strapi_api_token_permissions";
+  info: {
+    description: "";
+    displayName: "API Token Permission";
+    name: "API Token Permission";
+    pluralName: "api-token-permissions";
+    singularName: "api-token-permission";
+  };
+  options: {
+    draftAndPublish: false;
+  };
+  pluginOptions: {
+    "content-manager": {
+      visible: false;
+    };
+    "content-type-builder": {
+      visible: false;
+    };
+  };
+  attributes: {
+    action: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
       "oneToMany",
-      "plugin::users-permissions.user"
-    >;
-    createdAt: Schema.Attribute.DateTime;
-    updatedAt: Schema.Attribute.DateTime;
-    publishedAt: Schema.Attribute.DateTime;
-    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
-      Schema.Attribute.Private;
-    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
-      Schema.Attribute.Private;
-    locale: Schema.Attribute.String;
-  };
-}
-
-export interface PluginUsersPermissionsUser
-  extends Struct.CollectionTypeSchema {
-  collectionName: "up_users";
-  info: {
-    name: "user";
-    description: "";
-    singularName: "user";
-    pluralName: "users";
-    displayName: "User";
-  };
-  options: {
-    timestamps: true;
-    draftAndPublish: false;
-  };
-  attributes: {
-    username: Schema.Attribute.String &
-      Schema.Attribute.Required &
-      Schema.Attribute.Unique &
-      Schema.Attribute.SetMinMaxLength<{
-        minLength: 3;
-      }>;
-    email: Schema.Attribute.Email &
-      Schema.Attribute.Required &
-      Schema.Attribute.SetMinMaxLength<{
-        minLength: 6;
-      }>;
-    provider: Schema.Attribute.String;
-    password: Schema.Attribute.Password &
-      Schema.Attribute.Private &
-      Schema.Attribute.SetMinMaxLength<{
-        minLength: 6;
-      }>;
-    resetPasswordToken: Schema.Attribute.String & Schema.Attribute.Private;
-    confirmationToken: Schema.Attribute.String & Schema.Attribute.Private;
-    confirmed: Schema.Attribute.Boolean & Schema.Attribute.DefaultTo<false>;
-    blocked: Schema.Attribute.Boolean & Schema.Attribute.DefaultTo<false>;
-    role: Schema.Attribute.Relation<
-      "manyToOne",
-      "plugin::users-permissions.role"
-    >;
-    createdAt: Schema.Attribute.DateTime;
-    updatedAt: Schema.Attribute.DateTime;
-    publishedAt: Schema.Attribute.DateTime;
-    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
-      Schema.Attribute.Private;
-    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
-      Schema.Attribute.Private;
-    locale: Schema.Attribute.String;
-  };
-}
-
-export interface ApiFinancialCurrencyConversion
-  extends Struct.CollectionTypeSchema {
-  collectionName: "currency_conversions";
-  info: {
-    singularName: "currency-conversion";
-    pluralName: "currency-conversions";
-    displayName: "Financial.CurrencyConversions";
-  };
-  options: {
-    draftAndPublish: false;
-  };
-  attributes: {
-    year: Schema.Attribute.String &
-      Schema.Attribute.Required &
-      Schema.Attribute.SetMinMaxLength<{
-        maxLength: 4;
-      }>;
-    month: Schema.Attribute.Integer &
-      Schema.Attribute.Required &
-      Schema.Attribute.SetMinMax<
-        {
-          min: 1;
-          max: 12;
-        },
-        number
-      >;
-    currency: Schema.Attribute.Enumeration<
-      ["USD", "GBP", "EUR", "LBP", "LTL", "RSD", "BAM"]
+      "admin::api-token-permission"
     > &
-      Schema.Attribute.Required;
-    equivalentToUSD: Schema.Attribute.Float & Schema.Attribute.Required;
-    source: Schema.Attribute.String;
-    notes: Schema.Attribute.Text;
-    createdAt: Schema.Attribute.DateTime;
-    updatedAt: Schema.Attribute.DateTime;
-    publishedAt: Schema.Attribute.DateTime;
-    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
       Schema.Attribute.Private;
+    publishedAt: Schema.Attribute.DateTime;
+    token: Schema.Attribute.Relation<"manyToOne", "admin::api-token">;
+    updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
       Schema.Attribute.Private;
-    locale: Schema.Attribute.String;
-  };
-}
-
-export interface ApiGeoCountry extends Struct.CollectionTypeSchema {
-  collectionName: "countries";
-  info: {
-    singularName: "country";
-    pluralName: "countries";
-    displayName: "Geo.Country";
-  };
-  options: {
-    draftAndPublish: false;
-  };
-  attributes: {
-    Name: Schema.Attribute.String &
-      Schema.Attribute.Required &
-      Schema.Attribute.Unique;
-    Code: Schema.Attribute.String &
-      Schema.Attribute.Required &
-      Schema.Attribute.Unique &
-      Schema.Attribute.SetMinMaxLength<{
-        maxLength: 3;
-      }>;
-    Slug: Schema.Attribute.String;
-    createdAt: Schema.Attribute.DateTime;
-    updatedAt: Schema.Attribute.DateTime;
-    publishedAt: Schema.Attribute.DateTime;
-    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
-      Schema.Attribute.Private;
-    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
-      Schema.Attribute.Private;
-    locale: Schema.Attribute.String;
-  };
-}
-
-export interface ApiGeoRegion extends Struct.CollectionTypeSchema {
-  collectionName: "regions";
-  info: {
-    singularName: "region";
-    pluralName: "regions";
-    displayName: "Geo.Region";
-  };
-  options: {
-    draftAndPublish: false;
-  };
-  attributes: {
-    Name: Schema.Attribute.String &
-      Schema.Attribute.Required &
-      Schema.Attribute.Unique;
-    Slug: Schema.Attribute.String;
-    Map: Schema.Attribute.Media<"images">;
-    Overview: Schema.Attribute.RichText;
-    GovernmentResponse: Schema.Attribute.RichText;
-    Subregions: Schema.Attribute.Relation<"oneToMany", "api::geo.subregion">;
-    Countries: Schema.Attribute.Relation<"oneToMany", "api::geo.country">;
-    createdAt: Schema.Attribute.DateTime;
-    updatedAt: Schema.Attribute.DateTime;
-    publishedAt: Schema.Attribute.DateTime;
-    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
-      Schema.Attribute.Private;
-    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
-      Schema.Attribute.Private;
-    locale: Schema.Attribute.String;
-  };
-}
-
-export interface ApiGeoSubregion extends Struct.CollectionTypeSchema {
-  collectionName: "subregions";
-  info: {
-    singularName: "subregion";
-    pluralName: "subregions";
-    displayName: "Geo.Subregion";
-  };
-  options: {
-    draftAndPublish: false;
-  };
-  attributes: {
-    Name: Schema.Attribute.String &
-      Schema.Attribute.Required &
-      Schema.Attribute.Unique;
-    Slug: Schema.Attribute.String;
-    Map: Schema.Attribute.Media<"images">;
-    Overview: Schema.Attribute.RichText;
-    GovernmentResponse: Schema.Attribute.RichText;
-    Region: Schema.Attribute.Relation<"manyToOne", "api::geo.region">;
-    Country: Schema.Attribute.Relation<"oneToOne", "api::geo.country">;
-    createdAt: Schema.Attribute.DateTime;
-    updatedAt: Schema.Attribute.DateTime;
-    publishedAt: Schema.Attribute.DateTime;
-    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
-      Schema.Attribute.Private;
-    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
-      Schema.Attribute.Private;
-    locale: Schema.Attribute.String;
-  };
-}
-
-export interface ApiGroupGroup extends Struct.CollectionTypeSchema {
-  collectionName: "groups";
-  info: {
-    singularName: "group";
-    pluralName: "groups";
-    displayName: "Group";
-  };
-  options: {
-    draftAndPublish: false;
-  };
-  attributes: {
-    shortName: Schema.Attribute.String;
-    groupName: Schema.Attribute.String;
-    umbrellaOrganisation: Schema.Attribute.String;
-    region: Schema.Attribute.Relation<"oneToOne", "api::geo.region">;
-    notes: Schema.Attribute.Text;
-    groupConvertFrom: Schema.Attribute.String;
-    shortNameStripped: Schema.Attribute.String;
-    groupNameStripped: Schema.Attribute.Text;
-    groupConvertFromStripped: Schema.Attribute.String;
-    groupType: Schema.Attribute.Enumeration<
-      ["Aid group", "In-Kind Donor", "Service Provider"]
-    >;
-    number: Schema.Attribute.Integer;
-    createdAt: Schema.Attribute.DateTime;
-    updatedAt: Schema.Attribute.DateTime;
-    publishedAt: Schema.Attribute.DateTime;
-    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
-      Schema.Attribute.Private;
-    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
-      Schema.Attribute.Private;
-    locale: Schema.Attribute.String;
-  };
-}
-
-export interface ApiNeedsAssessmentNeed extends Struct.CollectionTypeSchema {
-  collectionName: "needs";
-  info: {
-    singularName: "need";
-    pluralName: "needs";
-    displayName: "NeedsAssessment.Need";
-  };
-  options: {
-    draftAndPublish: false;
-  };
-  attributes: {
-    survey: Schema.Attribute.Relation<
-      "manyToOne",
-      "api::needs-assessment.survey"
-    >;
-    region: Schema.Attribute.Relation<"oneToOne", "api::geo.region">;
-    subregion: Schema.Attribute.Relation<"oneToOne", "api::geo.subregion">;
-    item: Schema.Attribute.Relation<"oneToOne", "api::product.item">;
-    need: Schema.Attribute.Integer & Schema.Attribute.Required;
-    createdAt: Schema.Attribute.DateTime;
-    updatedAt: Schema.Attribute.DateTime;
-    publishedAt: Schema.Attribute.DateTime;
-    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
-      Schema.Attribute.Private;
-    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
-      Schema.Attribute.Private;
-    locale: Schema.Attribute.String;
-  };
-}
-
-export interface ApiNeedsAssessmentSurvey extends Struct.CollectionTypeSchema {
-  collectionName: "surveys";
-  info: {
-    singularName: "survey";
-    pluralName: "surveys";
-    displayName: "NeedsAssessment.Survey";
-  };
-  options: {
-    draftAndPublish: false;
-  };
-  attributes: {
-    year: Schema.Attribute.String &
-      Schema.Attribute.Required &
-      Schema.Attribute.SetMinMaxLength<{
-        maxLength: 4;
-      }>;
-    quarter: Schema.Attribute.Enumeration<["Q1", "Q2", "Q3", "Q4"]> &
-      Schema.Attribute.Required;
-    needs: Schema.Attribute.Relation<"oneToMany", "api::needs-assessment.need">;
-    createdAt: Schema.Attribute.DateTime;
-    updatedAt: Schema.Attribute.DateTime;
-    publishedAt: Schema.Attribute.DateTime;
-    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
-      Schema.Attribute.Private;
-    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
-      Schema.Attribute.Private;
-    locale: Schema.Attribute.String;
-  };
-}
-
-export interface ApiProductCategory extends Struct.CollectionTypeSchema {
-  collectionName: "categories";
-  info: {
-    singularName: "category";
-    pluralName: "categories";
-    displayName: "Product.Category";
-  };
-  options: {
-    draftAndPublish: false;
-  };
-  attributes: {
-    name: Schema.Attribute.String &
-      Schema.Attribute.Required &
-      Schema.Attribute.Unique;
-    items: Schema.Attribute.Relation<"oneToMany", "api::product.item">;
-    createdAt: Schema.Attribute.DateTime;
-    updatedAt: Schema.Attribute.DateTime;
-    publishedAt: Schema.Attribute.DateTime;
-    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
-      Schema.Attribute.Private;
-    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
-      Schema.Attribute.Private;
-    locale: Schema.Attribute.String;
-  };
-}
-
-export interface ApiProductItem extends Struct.CollectionTypeSchema {
-  collectionName: "items";
-  info: {
-    singularName: "item";
-    pluralName: "items";
-    displayName: "Product.Item";
-  };
-  options: {
-    draftAndPublish: false;
-  };
-  attributes: {
-    name: Schema.Attribute.String & Schema.Attribute.Required;
-    age_gender: Schema.Attribute.String;
-    size_style: Schema.Attribute.String;
-    category: Schema.Attribute.Relation<"manyToOne", "api::product.category">;
-    volume: Schema.Attribute.Component<"product.volume", true>;
-    weight: Schema.Attribute.Component<"product.weight", true>;
-    needsMet: Schema.Attribute.Component<"product.needs-met", false>;
-    secondHand: Schema.Attribute.Component<"product.second-hand", false>;
-    value: Schema.Attribute.Component<"product.value", true>;
-    packSize: Schema.Attribute.Integer &
-      Schema.Attribute.Required &
-      Schema.Attribute.SetMinMax<
-        {
-          min: 1;
-        },
-        number
-      > &
-      Schema.Attribute.DefaultTo<1>;
-    createdAt: Schema.Attribute.DateTime;
-    updatedAt: Schema.Attribute.DateTime;
-    publishedAt: Schema.Attribute.DateTime;
-    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
-      Schema.Attribute.Private;
-    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
-      Schema.Attribute.Private;
-    locale: Schema.Attribute.String;
-  };
-}
-
-export interface ApiReportingCargo extends Struct.CollectionTypeSchema {
-  collectionName: "cargos";
-  info: {
-    singularName: "cargo";
-    pluralName: "cargos";
-    displayName: "Reporting.Cargo";
-  };
-  options: {
-    draftAndPublish: false;
-  };
-  attributes: {
-    packageCount: Schema.Attribute.Integer;
-    packageUnit: Schema.Attribute.Enumeration<
-      [
-        "Bag",
-        "Medium Bag",
-        "Large Bag",
-        "Box",
-        "Banana Box",
-        "Pallet",
-        "Euro Pallet",
-        "Item",
-        "Single Item",
-      ]
-    >;
-    used: Schema.Attribute.Boolean;
-    itemCount: Schema.Attribute.Integer;
-    valueOverride: Schema.Attribute.Boolean;
-    valueOverrideCurrency: Schema.Attribute.Enumeration<
-      ["USD", "GBP", "EUR", "LBP", "LTL", "RSD", "BAM"]
-    >;
-    normalizedValuePerItem: Schema.Attribute.Decimal;
-    totalNormalizedValue: Schema.Attribute.Decimal;
-    valueInSendingCountry: Schema.Attribute.Decimal;
-    valueInReceivingCountry: Schema.Attribute.Decimal;
-    totalNeedsMet: Schema.Attribute.Decimal;
-    shipment: Schema.Attribute.Relation<"manyToOne", "api::reporting.shipment">;
-    item: Schema.Attribute.Relation<"oneToOne", "api::product.item">;
-    sendingCountry: Schema.Attribute.Relation<"oneToOne", "api::geo.country">;
-    receivingCountry: Schema.Attribute.Relation<"oneToOne", "api::geo.country">;
-    countryGDPContextCostOverride: Schema.Attribute.Relation<
-      "oneToOne",
-      "api::geo.country"
-    >;
-    sender: Schema.Attribute.Relation<"oneToOne", "api::group.group">;
-    receiver: Schema.Attribute.Relation<"oneToOne", "api::group.group">;
-    createdAt: Schema.Attribute.DateTime;
-    updatedAt: Schema.Attribute.DateTime;
-    publishedAt: Schema.Attribute.DateTime;
-    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
-      Schema.Attribute.Private;
-    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
-      Schema.Attribute.Private;
-    locale: Schema.Attribute.String;
-  };
-}
-
-export interface ApiReportingMovement extends Struct.CollectionTypeSchema {
-  collectionName: "movements";
-  info: {
-    singularName: "movement";
-    pluralName: "movements";
-    displayName: "Reporting.Movement";
-  };
-  options: {
-    draftAndPublish: false;
-  };
-  attributes: {
-    shipment: Schema.Attribute.Relation<"oneToOne", "api::reporting.shipment">;
-    segment: Schema.Attribute.Enumeration<
-      ["First Mile", "Last Mile", "Main Leg", "Main Leg-Cont"]
-    >;
-    pickupDate: Schema.Attribute.Date;
-    dropoffDate: Schema.Attribute.Date;
-    packageCount: Schema.Attribute.Integer;
-    packagingType: Schema.Attribute.String;
-    totalCargoVolM3: Schema.Attribute.Decimal;
-    totalCargoWeightKG: Schema.Attribute.Decimal;
-    vehicleCount: Schema.Attribute.Integer;
-    pickUpAddress: Schema.Attribute.Text;
-    dropOffAddress: Schema.Attribute.Text;
-    distanceKM: Schema.Attribute.Integer;
-    notes: Schema.Attribute.Text;
-    deliveryMethod: Schema.Attribute.Enumeration<
-      [
-        "FTL",
-        "LTL",
-        "Box Truck",
-        "Van",
-        "Personal Vehicle",
-        "FCL: 20 ft",
-        "FCL: 40 ft",
-        "FCL: 20 ft HC",
-        "FCL: 40 ft HC",
-        "LCL",
-        "Rail",
-        "Air",
-      ]
-    >;
-    involvement: Schema.Attribute.Enumeration<
-      ["Advised", "Assisted", "Organized", "Not involved"]
-    >;
-    serviceProvider: Schema.Attribute.Relation<"oneToOne", "api::group.group">;
-    createdAt: Schema.Attribute.DateTime;
-    updatedAt: Schema.Attribute.DateTime;
-    publishedAt: Schema.Attribute.DateTime;
-    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
-      Schema.Attribute.Private;
-    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
-      Schema.Attribute.Private;
-    locale: Schema.Attribute.String;
-  };
-}
-
-export interface ApiReportingShipment extends Struct.CollectionTypeSchema {
-  collectionName: "shipments";
-  info: {
-    singularName: "shipment";
-    pluralName: "shipments";
-    displayName: "Reporting.Shipment";
-    description: "";
-  };
-  options: {
-    draftAndPublish: false;
-  };
-  attributes: {
-    cargo: Schema.Attribute.Relation<"oneToMany", "api::reporting.cargo">;
-    carrierId: Schema.Attribute.String;
-    carbonOffsetPaid: Schema.Attribute.Boolean;
-    CO2TonsGenerated: Schema.Attribute.Decimal;
-    carbonOffsetCost: Schema.Attribute.Decimal;
-    notes: Schema.Attribute.Text;
-    type: Schema.Attribute.Enumeration<
-      ["Regular Route", "Ad Hoc", "Aid Swap/Local Transfer", "Other"]
-    >;
-    DARoles: Schema.Attribute.JSON;
-    sendingCountry: Schema.Attribute.Relation<"oneToOne", "api::geo.country">;
-    receivingCountry: Schema.Attribute.Relation<"oneToOne", "api::geo.country">;
-    number: Schema.Attribute.String &
-      Schema.Attribute.Required &
-      Schema.Attribute.Unique;
-    project: Schema.Attribute.Enumeration<
-      [
-        "Covid 19",
-        "Disaster Relief",
-        "Moria Fire",
-        "Refugee Aid - Europe",
-        "Refugee Aid - Lebanon",
-        "Social Enterprise Support",
-        "Ukraine",
-        "US ARR",
-        "Other",
-      ]
-    >;
-    importer: Schema.Attribute.Relation<"oneToOne", "api::group.group">;
-    exporter: Schema.Attribute.Relation<"oneToOne", "api::group.group">;
-    createdAt: Schema.Attribute.DateTime;
-    updatedAt: Schema.Attribute.DateTime;
-    publishedAt: Schema.Attribute.DateTime;
-    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
-      Schema.Attribute.Private;
-    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
-      Schema.Attribute.Private;
-    locale: Schema.Attribute.String;
-  };
-}
-
-export interface ApiTeamMember extends Struct.CollectionTypeSchema {
-  collectionName: "members";
-  info: {
-    singularName: "member";
-    pluralName: "members";
-    displayName: "Team.Member";
-  };
-  options: {
-    draftAndPublish: true;
-  };
-  attributes: {
-    Name: Schema.Attribute.String &
-      Schema.Attribute.Required &
-      Schema.Attribute.Unique;
-    Pronouns: Schema.Attribute.String;
-    Profile: Schema.Attribute.Media<"images"> & Schema.Attribute.Required;
-    From: Schema.Attribute.Relation<"oneToOne", "api::geo.country">;
-    Bio: Schema.Attribute.RichText;
-    Roles: Schema.Attribute.Component<"team.role", true> &
-      Schema.Attribute.Required;
-    createdAt: Schema.Attribute.DateTime;
-    updatedAt: Schema.Attribute.DateTime;
-    publishedAt: Schema.Attribute.DateTime;
-    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
-      Schema.Attribute.Private;
-    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
-      Schema.Attribute.Private;
-    locale: Schema.Attribute.String;
   };
 }
 
 export interface AdminPermission extends Struct.CollectionTypeSchema {
   collectionName: "admin_permissions";
   info: {
-    name: "Permission";
     description: "";
-    singularName: "permission";
-    pluralName: "permissions";
     displayName: "Permission";
+    name: "Permission";
+    pluralName: "permissions";
+    singularName: "permission";
   };
   options: {
     draftAndPublish: false;
@@ -1002,96 +130,34 @@ export interface AdminPermission extends Struct.CollectionTypeSchema {
         minLength: 1;
       }>;
     actionParameters: Schema.Attribute.JSON & Schema.Attribute.DefaultTo<{}>;
+    conditions: Schema.Attribute.JSON & Schema.Attribute.DefaultTo<[]>;
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<"oneToMany", "admin::permission"> &
+      Schema.Attribute.Private;
+    properties: Schema.Attribute.JSON & Schema.Attribute.DefaultTo<{}>;
+    publishedAt: Schema.Attribute.DateTime;
+    role: Schema.Attribute.Relation<"manyToOne", "admin::role">;
     subject: Schema.Attribute.String &
       Schema.Attribute.SetMinMaxLength<{
         minLength: 1;
       }>;
-    properties: Schema.Attribute.JSON & Schema.Attribute.DefaultTo<{}>;
-    conditions: Schema.Attribute.JSON & Schema.Attribute.DefaultTo<[]>;
-    role: Schema.Attribute.Relation<"manyToOne", "admin::role">;
-    createdAt: Schema.Attribute.DateTime;
     updatedAt: Schema.Attribute.DateTime;
-    publishedAt: Schema.Attribute.DateTime;
-    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
-      Schema.Attribute.Private;
     updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
       Schema.Attribute.Private;
-    locale: Schema.Attribute.String;
-  };
-}
-
-export interface AdminUser extends Struct.CollectionTypeSchema {
-  collectionName: "admin_users";
-  info: {
-    name: "User";
-    description: "";
-    singularName: "user";
-    pluralName: "users";
-    displayName: "User";
-  };
-  options: {
-    draftAndPublish: false;
-  };
-  pluginOptions: {
-    "content-manager": {
-      visible: false;
-    };
-    "content-type-builder": {
-      visible: false;
-    };
-  };
-  attributes: {
-    firstname: Schema.Attribute.String &
-      Schema.Attribute.SetMinMaxLength<{
-        minLength: 1;
-      }>;
-    lastname: Schema.Attribute.String &
-      Schema.Attribute.SetMinMaxLength<{
-        minLength: 1;
-      }>;
-    username: Schema.Attribute.String;
-    email: Schema.Attribute.Email &
-      Schema.Attribute.Required &
-      Schema.Attribute.Private &
-      Schema.Attribute.Unique &
-      Schema.Attribute.SetMinMaxLength<{
-        minLength: 6;
-      }>;
-    password: Schema.Attribute.Password &
-      Schema.Attribute.Private &
-      Schema.Attribute.SetMinMaxLength<{
-        minLength: 6;
-      }>;
-    resetPasswordToken: Schema.Attribute.String & Schema.Attribute.Private;
-    registrationToken: Schema.Attribute.String & Schema.Attribute.Private;
-    isActive: Schema.Attribute.Boolean &
-      Schema.Attribute.Private &
-      Schema.Attribute.DefaultTo<false>;
-    roles: Schema.Attribute.Relation<"manyToMany", "admin::role"> &
-      Schema.Attribute.Private;
-    blocked: Schema.Attribute.Boolean &
-      Schema.Attribute.Private &
-      Schema.Attribute.DefaultTo<false>;
-    preferedLanguage: Schema.Attribute.String;
-    createdAt: Schema.Attribute.DateTime;
-    updatedAt: Schema.Attribute.DateTime;
-    publishedAt: Schema.Attribute.DateTime;
-    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
-      Schema.Attribute.Private;
-    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
-      Schema.Attribute.Private;
-    locale: Schema.Attribute.String;
   };
 }
 
 export interface AdminRole extends Struct.CollectionTypeSchema {
   collectionName: "admin_roles";
   info: {
-    name: "Role";
     description: "";
-    singularName: "role";
-    pluralName: "roles";
     displayName: "Role";
+    name: "Role";
+    pluralName: "roles";
+    singularName: "role";
   };
   options: {
     draftAndPublish: false;
@@ -1105,136 +171,42 @@ export interface AdminRole extends Struct.CollectionTypeSchema {
     };
   };
   attributes: {
-    name: Schema.Attribute.String &
-      Schema.Attribute.Required &
-      Schema.Attribute.Unique &
-      Schema.Attribute.SetMinMaxLength<{
-        minLength: 1;
-      }>;
     code: Schema.Attribute.String &
       Schema.Attribute.Required &
       Schema.Attribute.Unique &
       Schema.Attribute.SetMinMaxLength<{
         minLength: 1;
       }>;
-    description: Schema.Attribute.String;
-    users: Schema.Attribute.Relation<"manyToMany", "admin::user">;
-    permissions: Schema.Attribute.Relation<"oneToMany", "admin::permission">;
     createdAt: Schema.Attribute.DateTime;
-    updatedAt: Schema.Attribute.DateTime;
-    publishedAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
       Schema.Attribute.Private;
-    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+    description: Schema.Attribute.String;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<"oneToMany", "admin::role"> &
       Schema.Attribute.Private;
-    locale: Schema.Attribute.String;
-  };
-}
-
-export interface AdminApiToken extends Struct.CollectionTypeSchema {
-  collectionName: "strapi_api_tokens";
-  info: {
-    name: "Api Token";
-    singularName: "api-token";
-    pluralName: "api-tokens";
-    displayName: "Api Token";
-    description: "";
-  };
-  options: {
-    draftAndPublish: false;
-  };
-  pluginOptions: {
-    "content-manager": {
-      visible: false;
-    };
-    "content-type-builder": {
-      visible: false;
-    };
-  };
-  attributes: {
     name: Schema.Attribute.String &
       Schema.Attribute.Required &
       Schema.Attribute.Unique &
       Schema.Attribute.SetMinMaxLength<{
         minLength: 1;
       }>;
-    description: Schema.Attribute.String &
-      Schema.Attribute.SetMinMaxLength<{
-        minLength: 1;
-      }> &
-      Schema.Attribute.DefaultTo<"">;
-    type: Schema.Attribute.Enumeration<["read-only", "full-access", "custom"]> &
-      Schema.Attribute.Required &
-      Schema.Attribute.DefaultTo<"read-only">;
-    accessKey: Schema.Attribute.String &
-      Schema.Attribute.Required &
-      Schema.Attribute.SetMinMaxLength<{
-        minLength: 1;
-      }>;
-    lastUsedAt: Schema.Attribute.DateTime;
-    permissions: Schema.Attribute.Relation<
-      "oneToMany",
-      "admin::api-token-permission"
-    >;
-    expiresAt: Schema.Attribute.DateTime;
-    lifespan: Schema.Attribute.BigInteger;
-    createdAt: Schema.Attribute.DateTime;
-    updatedAt: Schema.Attribute.DateTime;
+    permissions: Schema.Attribute.Relation<"oneToMany", "admin::permission">;
     publishedAt: Schema.Attribute.DateTime;
-    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
-      Schema.Attribute.Private;
+    updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
       Schema.Attribute.Private;
-    locale: Schema.Attribute.String;
-  };
-}
-
-export interface AdminApiTokenPermission extends Struct.CollectionTypeSchema {
-  collectionName: "strapi_api_token_permissions";
-  info: {
-    name: "API Token Permission";
-    description: "";
-    singularName: "api-token-permission";
-    pluralName: "api-token-permissions";
-    displayName: "API Token Permission";
-  };
-  options: {
-    draftAndPublish: false;
-  };
-  pluginOptions: {
-    "content-manager": {
-      visible: false;
-    };
-    "content-type-builder": {
-      visible: false;
-    };
-  };
-  attributes: {
-    action: Schema.Attribute.String &
-      Schema.Attribute.Required &
-      Schema.Attribute.SetMinMaxLength<{
-        minLength: 1;
-      }>;
-    token: Schema.Attribute.Relation<"manyToOne", "admin::api-token">;
-    createdAt: Schema.Attribute.DateTime;
-    updatedAt: Schema.Attribute.DateTime;
-    publishedAt: Schema.Attribute.DateTime;
-    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
-      Schema.Attribute.Private;
-    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
-      Schema.Attribute.Private;
-    locale: Schema.Attribute.String;
+    users: Schema.Attribute.Relation<"manyToMany", "admin::user">;
   };
 }
 
 export interface AdminTransferToken extends Struct.CollectionTypeSchema {
   collectionName: "strapi_transfer_tokens";
   info: {
-    name: "Transfer Token";
-    singularName: "transfer-token";
-    pluralName: "transfer-tokens";
-    displayName: "Transfer Token";
     description: "";
+    displayName: "Transfer Token";
+    name: "Transfer Token";
+    pluralName: "transfer-tokens";
+    singularName: "transfer-token";
   };
   options: {
     draftAndPublish: false;
@@ -1248,37 +220,42 @@ export interface AdminTransferToken extends Struct.CollectionTypeSchema {
     };
   };
   attributes: {
+    accessKey: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+    description: Schema.Attribute.String &
+      Schema.Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }> &
+      Schema.Attribute.DefaultTo<"">;
+    expiresAt: Schema.Attribute.DateTime;
+    lastUsedAt: Schema.Attribute.DateTime;
+    lifespan: Schema.Attribute.BigInteger;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      "oneToMany",
+      "admin::transfer-token"
+    > &
+      Schema.Attribute.Private;
     name: Schema.Attribute.String &
       Schema.Attribute.Required &
       Schema.Attribute.Unique &
       Schema.Attribute.SetMinMaxLength<{
         minLength: 1;
       }>;
-    description: Schema.Attribute.String &
-      Schema.Attribute.SetMinMaxLength<{
-        minLength: 1;
-      }> &
-      Schema.Attribute.DefaultTo<"">;
-    accessKey: Schema.Attribute.String &
-      Schema.Attribute.Required &
-      Schema.Attribute.SetMinMaxLength<{
-        minLength: 1;
-      }>;
-    lastUsedAt: Schema.Attribute.DateTime;
     permissions: Schema.Attribute.Relation<
       "oneToMany",
       "admin::transfer-token-permission"
     >;
-    expiresAt: Schema.Attribute.DateTime;
-    lifespan: Schema.Attribute.BigInteger;
-    createdAt: Schema.Attribute.DateTime;
-    updatedAt: Schema.Attribute.DateTime;
     publishedAt: Schema.Attribute.DateTime;
-    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
-      Schema.Attribute.Private;
+    updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
       Schema.Attribute.Private;
-    locale: Schema.Attribute.String;
   };
 }
 
@@ -1286,11 +263,11 @@ export interface AdminTransferTokenPermission
   extends Struct.CollectionTypeSchema {
   collectionName: "strapi_transfer_token_permissions";
   info: {
-    name: "Transfer Token Permission";
     description: "";
-    singularName: "transfer-token-permission";
-    pluralName: "transfer-token-permissions";
     displayName: "Transfer Token Permission";
+    name: "Transfer Token Permission";
+    pluralName: "transfer-token-permissions";
+    singularName: "transfer-token-permission";
   };
   options: {
     draftAndPublish: false;
@@ -1309,32 +286,1183 @@ export interface AdminTransferTokenPermission
       Schema.Attribute.SetMinMaxLength<{
         minLength: 1;
       }>;
-    token: Schema.Attribute.Relation<"manyToOne", "admin::transfer-token">;
     createdAt: Schema.Attribute.DateTime;
-    updatedAt: Schema.Attribute.DateTime;
-    publishedAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
       Schema.Attribute.Private;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      "oneToMany",
+      "admin::transfer-token-permission"
+    > &
+      Schema.Attribute.Private;
+    publishedAt: Schema.Attribute.DateTime;
+    token: Schema.Attribute.Relation<"manyToOne", "admin::transfer-token">;
+    updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
       Schema.Attribute.Private;
-    locale: Schema.Attribute.String;
+  };
+}
+
+export interface AdminUser extends Struct.CollectionTypeSchema {
+  collectionName: "admin_users";
+  info: {
+    description: "";
+    displayName: "User";
+    name: "User";
+    pluralName: "users";
+    singularName: "user";
+  };
+  options: {
+    draftAndPublish: false;
+  };
+  pluginOptions: {
+    "content-manager": {
+      visible: false;
+    };
+    "content-type-builder": {
+      visible: false;
+    };
+  };
+  attributes: {
+    blocked: Schema.Attribute.Boolean &
+      Schema.Attribute.Private &
+      Schema.Attribute.DefaultTo<false>;
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+    email: Schema.Attribute.Email &
+      Schema.Attribute.Required &
+      Schema.Attribute.Private &
+      Schema.Attribute.Unique &
+      Schema.Attribute.SetMinMaxLength<{
+        minLength: 6;
+      }>;
+    firstname: Schema.Attribute.String &
+      Schema.Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
+    isActive: Schema.Attribute.Boolean &
+      Schema.Attribute.Private &
+      Schema.Attribute.DefaultTo<false>;
+    lastname: Schema.Attribute.String &
+      Schema.Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<"oneToMany", "admin::user"> &
+      Schema.Attribute.Private;
+    password: Schema.Attribute.Password &
+      Schema.Attribute.Private &
+      Schema.Attribute.SetMinMaxLength<{
+        minLength: 6;
+      }>;
+    preferedLanguage: Schema.Attribute.String;
+    publishedAt: Schema.Attribute.DateTime;
+    registrationToken: Schema.Attribute.String & Schema.Attribute.Private;
+    resetPasswordToken: Schema.Attribute.String & Schema.Attribute.Private;
+    roles: Schema.Attribute.Relation<"manyToMany", "admin::role"> &
+      Schema.Attribute.Private;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+    username: Schema.Attribute.String;
+  };
+}
+
+export interface ApiFinancialCurrencyConversion
+  extends Struct.CollectionTypeSchema {
+  collectionName: "currency_conversions";
+  info: {
+    displayName: "Financial.CurrencyConversions";
+    pluralName: "currency-conversions";
+    singularName: "currency-conversion";
+  };
+  options: {
+    draftAndPublish: false;
+  };
+  attributes: {
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+    currency: Schema.Attribute.Enumeration<
+      ["USD", "GBP", "EUR", "LBP", "LTL", "RSD", "BAM"]
+    > &
+      Schema.Attribute.Required;
+    equivalentToUSD: Schema.Attribute.Float & Schema.Attribute.Required;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      "oneToMany",
+      "api::financial.currency-conversion"
+    > &
+      Schema.Attribute.Private;
+    month: Schema.Attribute.Integer &
+      Schema.Attribute.Required &
+      Schema.Attribute.SetMinMax<
+        {
+          max: 12;
+          min: 1;
+        },
+        number
+      >;
+    notes: Schema.Attribute.Text;
+    publishedAt: Schema.Attribute.DateTime;
+    source: Schema.Attribute.String;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+    year: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.SetMinMaxLength<{
+        maxLength: 4;
+      }>;
+  };
+}
+
+export interface ApiGeoCountry extends Struct.CollectionTypeSchema {
+  collectionName: "countries";
+  info: {
+    displayName: "Geo.Country";
+    pluralName: "countries";
+    singularName: "country";
+  };
+  options: {
+    draftAndPublish: false;
+  };
+  attributes: {
+    Code: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.Unique &
+      Schema.Attribute.SetMinMaxLength<{
+        maxLength: 3;
+      }>;
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<"oneToMany", "api::geo.country"> &
+      Schema.Attribute.Private;
+    Name: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.Unique;
+    publishedAt: Schema.Attribute.DateTime;
+    Slug: Schema.Attribute.String;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+  };
+}
+
+export interface ApiGeoRegion extends Struct.CollectionTypeSchema {
+  collectionName: "regions";
+  info: {
+    displayName: "Geo.Region";
+    pluralName: "regions";
+    singularName: "region";
+  };
+  options: {
+    draftAndPublish: false;
+  };
+  attributes: {
+    Countries: Schema.Attribute.Relation<"oneToMany", "api::geo.country">;
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+    GovernmentResponse: Schema.Attribute.RichText;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<"oneToMany", "api::geo.region"> &
+      Schema.Attribute.Private;
+    Map: Schema.Attribute.Media<"images">;
+    Name: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.Unique;
+    Overview: Schema.Attribute.RichText;
+    publishedAt: Schema.Attribute.DateTime;
+    Slug: Schema.Attribute.String;
+    Subregions: Schema.Attribute.Relation<"oneToMany", "api::geo.subregion">;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+  };
+}
+
+export interface ApiGeoSubregion extends Struct.CollectionTypeSchema {
+  collectionName: "subregions";
+  info: {
+    displayName: "Geo.Subregion";
+    pluralName: "subregions";
+    singularName: "subregion";
+  };
+  options: {
+    draftAndPublish: false;
+  };
+  attributes: {
+    Country: Schema.Attribute.Relation<"oneToOne", "api::geo.country">;
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+    GovernmentResponse: Schema.Attribute.RichText;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      "oneToMany",
+      "api::geo.subregion"
+    > &
+      Schema.Attribute.Private;
+    Map: Schema.Attribute.Media<"images">;
+    Name: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.Unique;
+    Overview: Schema.Attribute.RichText;
+    publishedAt: Schema.Attribute.DateTime;
+    Region: Schema.Attribute.Relation<"manyToOne", "api::geo.region">;
+    Slug: Schema.Attribute.String;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+  };
+}
+
+export interface ApiGroupGroup extends Struct.CollectionTypeSchema {
+  collectionName: "groups";
+  info: {
+    displayName: "Group";
+    pluralName: "groups";
+    singularName: "group";
+  };
+  options: {
+    draftAndPublish: false;
+  };
+  attributes: {
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+    groupConvertFrom: Schema.Attribute.String;
+    groupConvertFromStripped: Schema.Attribute.String;
+    groupName: Schema.Attribute.String;
+    groupNameStripped: Schema.Attribute.Text;
+    groupType: Schema.Attribute.Enumeration<
+      ["Aid group", "In-Kind Donor", "Service Provider"]
+    >;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<"oneToMany", "api::group.group"> &
+      Schema.Attribute.Private;
+    notes: Schema.Attribute.Text;
+    number: Schema.Attribute.Integer;
+    publishedAt: Schema.Attribute.DateTime;
+    region: Schema.Attribute.Relation<"oneToOne", "api::geo.region">;
+    shortName: Schema.Attribute.String;
+    shortNameStripped: Schema.Attribute.String;
+    umbrellaOrganisation: Schema.Attribute.String;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+  };
+}
+
+export interface ApiNeedsAssessmentNeed extends Struct.CollectionTypeSchema {
+  collectionName: "needs";
+  info: {
+    displayName: "NeedsAssessment.Need";
+    pluralName: "needs";
+    singularName: "need";
+  };
+  options: {
+    draftAndPublish: false;
+  };
+  attributes: {
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+    item: Schema.Attribute.Relation<"oneToOne", "api::product.item">;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      "oneToMany",
+      "api::needs-assessment.need"
+    > &
+      Schema.Attribute.Private;
+    need: Schema.Attribute.Integer & Schema.Attribute.Required;
+    publishedAt: Schema.Attribute.DateTime;
+    region: Schema.Attribute.Relation<"oneToOne", "api::geo.region">;
+    subregion: Schema.Attribute.Relation<"oneToOne", "api::geo.subregion">;
+    survey: Schema.Attribute.Relation<
+      "manyToOne",
+      "api::needs-assessment.survey"
+    >;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+  };
+}
+
+export interface ApiNeedsAssessmentSurvey extends Struct.CollectionTypeSchema {
+  collectionName: "surveys";
+  info: {
+    displayName: "NeedsAssessment.Survey";
+    pluralName: "surveys";
+    singularName: "survey";
+  };
+  options: {
+    draftAndPublish: false;
+  };
+  attributes: {
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      "oneToMany",
+      "api::needs-assessment.survey"
+    > &
+      Schema.Attribute.Private;
+    needs: Schema.Attribute.Relation<"oneToMany", "api::needs-assessment.need">;
+    publishedAt: Schema.Attribute.DateTime;
+    quarter: Schema.Attribute.Enumeration<["Q1", "Q2", "Q3", "Q4"]> &
+      Schema.Attribute.Required;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+    year: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.SetMinMaxLength<{
+        maxLength: 4;
+      }>;
+  };
+}
+
+export interface ApiProductCategory extends Struct.CollectionTypeSchema {
+  collectionName: "categories";
+  info: {
+    displayName: "Product.Category";
+    pluralName: "categories";
+    singularName: "category";
+  };
+  options: {
+    draftAndPublish: false;
+  };
+  attributes: {
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+    items: Schema.Attribute.Relation<"oneToMany", "api::product.item">;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      "oneToMany",
+      "api::product.category"
+    > &
+      Schema.Attribute.Private;
+    name: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.Unique;
+    publishedAt: Schema.Attribute.DateTime;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+  };
+}
+
+export interface ApiProductItem extends Struct.CollectionTypeSchema {
+  collectionName: "items";
+  info: {
+    displayName: "Product.Item";
+    pluralName: "items";
+    singularName: "item";
+  };
+  options: {
+    draftAndPublish: false;
+  };
+  attributes: {
+    age_gender: Schema.Attribute.String;
+    category: Schema.Attribute.Relation<"manyToOne", "api::product.category">;
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<"oneToMany", "api::product.item"> &
+      Schema.Attribute.Private;
+    name: Schema.Attribute.String & Schema.Attribute.Required;
+    needsMet: Schema.Attribute.Component<"product.needs-met", false>;
+    packSize: Schema.Attribute.Integer &
+      Schema.Attribute.Required &
+      Schema.Attribute.SetMinMax<
+        {
+          min: 1;
+        },
+        number
+      > &
+      Schema.Attribute.DefaultTo<1>;
+    publishedAt: Schema.Attribute.DateTime;
+    secondHand: Schema.Attribute.Component<"product.second-hand", false>;
+    size_style: Schema.Attribute.String;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+    value: Schema.Attribute.Component<"product.value", true>;
+    volume: Schema.Attribute.Component<"product.volume", true>;
+    weight: Schema.Attribute.Component<"product.weight", true>;
+  };
+}
+
+export interface ApiReportingCargo extends Struct.CollectionTypeSchema {
+  collectionName: "cargos";
+  info: {
+    displayName: "Reporting.Cargo";
+    pluralName: "cargos";
+    singularName: "cargo";
+  };
+  options: {
+    draftAndPublish: false;
+  };
+  attributes: {
+    countryGDPContextCostOverride: Schema.Attribute.Relation<
+      "oneToOne",
+      "api::geo.country"
+    >;
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+    item: Schema.Attribute.Relation<"oneToOne", "api::product.item">;
+    itemCount: Schema.Attribute.Integer;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      "oneToMany",
+      "api::reporting.cargo"
+    > &
+      Schema.Attribute.Private;
+    normalizedValuePerItem: Schema.Attribute.Decimal;
+    packageCount: Schema.Attribute.Integer;
+    packageUnit: Schema.Attribute.Enumeration<
+      [
+        "Bag",
+        "Medium Bag",
+        "Large Bag",
+        "Box",
+        "Banana Box",
+        "Pallet",
+        "Euro Pallet",
+        "Item",
+        "Single Item",
+      ]
+    >;
+    publishedAt: Schema.Attribute.DateTime;
+    receiver: Schema.Attribute.Relation<"oneToOne", "api::group.group">;
+    receivingCountry: Schema.Attribute.Relation<"oneToOne", "api::geo.country">;
+    sender: Schema.Attribute.Relation<"oneToOne", "api::group.group">;
+    sendingCountry: Schema.Attribute.Relation<"oneToOne", "api::geo.country">;
+    shipment: Schema.Attribute.Relation<"manyToOne", "api::reporting.shipment">;
+    totalNeedsMet: Schema.Attribute.Decimal;
+    totalNormalizedValue: Schema.Attribute.Decimal;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+    used: Schema.Attribute.Boolean;
+    valueInReceivingCountry: Schema.Attribute.Decimal;
+    valueInSendingCountry: Schema.Attribute.Decimal;
+    valueOverride: Schema.Attribute.Boolean;
+    valueOverrideCurrency: Schema.Attribute.Enumeration<
+      ["USD", "GBP", "EUR", "LBP", "LTL", "RSD", "BAM"]
+    >;
+  };
+}
+
+export interface ApiReportingMovement extends Struct.CollectionTypeSchema {
+  collectionName: "movements";
+  info: {
+    displayName: "Reporting.Movement";
+    pluralName: "movements";
+    singularName: "movement";
+  };
+  options: {
+    draftAndPublish: false;
+  };
+  attributes: {
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+    deliveryMethod: Schema.Attribute.Enumeration<
+      [
+        "FTL",
+        "LTL",
+        "Box Truck",
+        "Van",
+        "Personal Vehicle",
+        "FCL: 20 ft",
+        "FCL: 40 ft",
+        "FCL: 20 ft HC",
+        "FCL: 40 ft HC",
+        "LCL",
+        "Rail",
+        "Air",
+      ]
+    >;
+    distanceKM: Schema.Attribute.Integer;
+    dropOffAddress: Schema.Attribute.Text;
+    dropoffDate: Schema.Attribute.Date;
+    involvement: Schema.Attribute.Enumeration<
+      ["Advised", "Assisted", "Organized", "Not involved"]
+    >;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      "oneToMany",
+      "api::reporting.movement"
+    > &
+      Schema.Attribute.Private;
+    notes: Schema.Attribute.Text;
+    packageCount: Schema.Attribute.Integer;
+    packagingType: Schema.Attribute.String;
+    pickUpAddress: Schema.Attribute.Text;
+    pickupDate: Schema.Attribute.Date;
+    publishedAt: Schema.Attribute.DateTime;
+    segment: Schema.Attribute.Enumeration<
+      ["First Mile", "Last Mile", "Main Leg", "Main Leg-Cont"]
+    >;
+    serviceProvider: Schema.Attribute.Relation<"oneToOne", "api::group.group">;
+    shipment: Schema.Attribute.Relation<"oneToOne", "api::reporting.shipment">;
+    totalCargoVolM3: Schema.Attribute.Decimal;
+    totalCargoWeightKG: Schema.Attribute.Decimal;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+    vehicleCount: Schema.Attribute.Integer;
+  };
+}
+
+export interface ApiReportingShipment extends Struct.CollectionTypeSchema {
+  collectionName: "shipments";
+  info: {
+    description: "";
+    displayName: "Reporting.Shipment";
+    pluralName: "shipments";
+    singularName: "shipment";
+  };
+  options: {
+    draftAndPublish: false;
+  };
+  attributes: {
+    carbonOffsetCost: Schema.Attribute.Decimal;
+    carbonOffsetPaid: Schema.Attribute.Boolean;
+    cargo: Schema.Attribute.Relation<"oneToMany", "api::reporting.cargo">;
+    carrierId: Schema.Attribute.String;
+    CO2TonsGenerated: Schema.Attribute.Decimal;
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+    DARoles: Schema.Attribute.JSON;
+    exporter: Schema.Attribute.Relation<"oneToOne", "api::group.group">;
+    importer: Schema.Attribute.Relation<"oneToOne", "api::group.group">;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      "oneToMany",
+      "api::reporting.shipment"
+    > &
+      Schema.Attribute.Private;
+    notes: Schema.Attribute.Text;
+    number: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.Unique;
+    project: Schema.Attribute.Enumeration<
+      [
+        "Covid 19",
+        "Disaster Relief",
+        "Moria Fire",
+        "Refugee Aid - Europe",
+        "Refugee Aid - Lebanon",
+        "Social Enterprise Support",
+        "Ukraine",
+        "US ARR",
+        "Other",
+      ]
+    >;
+    publishedAt: Schema.Attribute.DateTime;
+    receivingCountry: Schema.Attribute.Relation<"oneToOne", "api::geo.country">;
+    sendingCountry: Schema.Attribute.Relation<"oneToOne", "api::geo.country">;
+    type: Schema.Attribute.Enumeration<
+      ["Regular Route", "Ad Hoc", "Aid Swap/Local Transfer", "Other"]
+    >;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+  };
+}
+
+export interface ApiTeamMember extends Struct.CollectionTypeSchema {
+  collectionName: "members";
+  info: {
+    displayName: "Team.Member";
+    pluralName: "members";
+    singularName: "member";
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    Bio: Schema.Attribute.RichText;
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+    From: Schema.Attribute.Relation<"oneToOne", "api::geo.country">;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<"oneToMany", "api::team.member"> &
+      Schema.Attribute.Private;
+    Name: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.Unique;
+    Profile: Schema.Attribute.Media<"images"> & Schema.Attribute.Required;
+    Pronouns: Schema.Attribute.String;
+    publishedAt: Schema.Attribute.DateTime;
+    Roles: Schema.Attribute.Component<"team.role", true> &
+      Schema.Attribute.Required;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+  };
+}
+
+export interface PluginContentReleasesRelease
+  extends Struct.CollectionTypeSchema {
+  collectionName: "strapi_releases";
+  info: {
+    displayName: "Release";
+    pluralName: "releases";
+    singularName: "release";
+  };
+  options: {
+    draftAndPublish: false;
+  };
+  pluginOptions: {
+    "content-manager": {
+      visible: false;
+    };
+    "content-type-builder": {
+      visible: false;
+    };
+  };
+  attributes: {
+    actions: Schema.Attribute.Relation<
+      "oneToMany",
+      "plugin::content-releases.release-action"
+    >;
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      "oneToMany",
+      "plugin::content-releases.release"
+    > &
+      Schema.Attribute.Private;
+    name: Schema.Attribute.String & Schema.Attribute.Required;
+    publishedAt: Schema.Attribute.DateTime;
+    releasedAt: Schema.Attribute.DateTime;
+    scheduledAt: Schema.Attribute.DateTime;
+    status: Schema.Attribute.Enumeration<
+      ["ready", "blocked", "failed", "done", "empty"]
+    > &
+      Schema.Attribute.Required;
+    timezone: Schema.Attribute.String;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+  };
+}
+
+export interface PluginContentReleasesReleaseAction
+  extends Struct.CollectionTypeSchema {
+  collectionName: "strapi_release_actions";
+  info: {
+    displayName: "Release Action";
+    pluralName: "release-actions";
+    singularName: "release-action";
+  };
+  options: {
+    draftAndPublish: false;
+  };
+  pluginOptions: {
+    "content-manager": {
+      visible: false;
+    };
+    "content-type-builder": {
+      visible: false;
+    };
+  };
+  attributes: {
+    contentType: Schema.Attribute.String & Schema.Attribute.Required;
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+    entryDocumentId: Schema.Attribute.String;
+    isEntryValid: Schema.Attribute.Boolean;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      "oneToMany",
+      "plugin::content-releases.release-action"
+    > &
+      Schema.Attribute.Private;
+    publishedAt: Schema.Attribute.DateTime;
+    release: Schema.Attribute.Relation<
+      "manyToOne",
+      "plugin::content-releases.release"
+    >;
+    type: Schema.Attribute.Enumeration<["publish", "unpublish"]> &
+      Schema.Attribute.Required;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+  };
+}
+
+export interface PluginI18NLocale extends Struct.CollectionTypeSchema {
+  collectionName: "i18n_locale";
+  info: {
+    collectionName: "locales";
+    description: "";
+    displayName: "Locale";
+    pluralName: "locales";
+    singularName: "locale";
+  };
+  options: {
+    draftAndPublish: false;
+  };
+  pluginOptions: {
+    "content-manager": {
+      visible: false;
+    };
+    "content-type-builder": {
+      visible: false;
+    };
+  };
+  attributes: {
+    code: Schema.Attribute.String & Schema.Attribute.Unique;
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      "oneToMany",
+      "plugin::i18n.locale"
+    > &
+      Schema.Attribute.Private;
+    name: Schema.Attribute.String &
+      Schema.Attribute.SetMinMax<
+        {
+          max: 50;
+          min: 1;
+        },
+        number
+      >;
+    publishedAt: Schema.Attribute.DateTime;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+  };
+}
+
+export interface PluginReviewWorkflowsWorkflow
+  extends Struct.CollectionTypeSchema {
+  collectionName: "strapi_workflows";
+  info: {
+    description: "";
+    displayName: "Workflow";
+    name: "Workflow";
+    pluralName: "workflows";
+    singularName: "workflow";
+  };
+  options: {
+    draftAndPublish: false;
+  };
+  pluginOptions: {
+    "content-manager": {
+      visible: false;
+    };
+    "content-type-builder": {
+      visible: false;
+    };
+  };
+  attributes: {
+    contentTypes: Schema.Attribute.JSON &
+      Schema.Attribute.Required &
+      Schema.Attribute.DefaultTo<"[]">;
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      "oneToMany",
+      "plugin::review-workflows.workflow"
+    > &
+      Schema.Attribute.Private;
+    name: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.Unique;
+    publishedAt: Schema.Attribute.DateTime;
+    stageRequiredToPublish: Schema.Attribute.Relation<
+      "oneToOne",
+      "plugin::review-workflows.workflow-stage"
+    >;
+    stages: Schema.Attribute.Relation<
+      "oneToMany",
+      "plugin::review-workflows.workflow-stage"
+    >;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+  };
+}
+
+export interface PluginReviewWorkflowsWorkflowStage
+  extends Struct.CollectionTypeSchema {
+  collectionName: "strapi_workflows_stages";
+  info: {
+    description: "";
+    displayName: "Stages";
+    name: "Workflow Stage";
+    pluralName: "workflow-stages";
+    singularName: "workflow-stage";
+  };
+  options: {
+    draftAndPublish: false;
+    version: "1.1.0";
+  };
+  pluginOptions: {
+    "content-manager": {
+      visible: false;
+    };
+    "content-type-builder": {
+      visible: false;
+    };
+  };
+  attributes: {
+    color: Schema.Attribute.String & Schema.Attribute.DefaultTo<"#4945FF">;
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      "oneToMany",
+      "plugin::review-workflows.workflow-stage"
+    > &
+      Schema.Attribute.Private;
+    name: Schema.Attribute.String;
+    permissions: Schema.Attribute.Relation<"manyToMany", "admin::permission">;
+    publishedAt: Schema.Attribute.DateTime;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+    workflow: Schema.Attribute.Relation<
+      "manyToOne",
+      "plugin::review-workflows.workflow"
+    >;
+  };
+}
+
+export interface PluginSlugifySlug extends Struct.CollectionTypeSchema {
+  collectionName: "slugs";
+  info: {
+    displayName: "slug";
+    pluralName: "slugs";
+    singularName: "slug";
+  };
+  options: {
+    comment: "";
+    draftAndPublish: false;
+  };
+  pluginOptions: {
+    "content-manager": {
+      visible: false;
+    };
+    "content-type-builder": {
+      visible: false;
+    };
+  };
+  attributes: {
+    count: Schema.Attribute.Integer;
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      "oneToMany",
+      "plugin::slugify.slug"
+    > &
+      Schema.Attribute.Private;
+    publishedAt: Schema.Attribute.DateTime;
+    slug: Schema.Attribute.Text;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+  };
+}
+
+export interface PluginUploadFile extends Struct.CollectionTypeSchema {
+  collectionName: "files";
+  info: {
+    description: "";
+    displayName: "File";
+    pluralName: "files";
+    singularName: "file";
+  };
+  options: {
+    draftAndPublish: false;
+  };
+  pluginOptions: {
+    "content-manager": {
+      visible: false;
+    };
+    "content-type-builder": {
+      visible: false;
+    };
+  };
+  attributes: {
+    alternativeText: Schema.Attribute.String;
+    caption: Schema.Attribute.String;
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+    ext: Schema.Attribute.String;
+    folder: Schema.Attribute.Relation<"manyToOne", "plugin::upload.folder"> &
+      Schema.Attribute.Private;
+    folderPath: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.Private &
+      Schema.Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
+    formats: Schema.Attribute.JSON;
+    hash: Schema.Attribute.String & Schema.Attribute.Required;
+    height: Schema.Attribute.Integer;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      "oneToMany",
+      "plugin::upload.file"
+    > &
+      Schema.Attribute.Private;
+    mime: Schema.Attribute.String & Schema.Attribute.Required;
+    name: Schema.Attribute.String & Schema.Attribute.Required;
+    previewUrl: Schema.Attribute.String;
+    provider: Schema.Attribute.String & Schema.Attribute.Required;
+    provider_metadata: Schema.Attribute.JSON;
+    publishedAt: Schema.Attribute.DateTime;
+    related: Schema.Attribute.Relation<"morphToMany">;
+    size: Schema.Attribute.Decimal & Schema.Attribute.Required;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+    url: Schema.Attribute.String & Schema.Attribute.Required;
+    width: Schema.Attribute.Integer;
+  };
+}
+
+export interface PluginUploadFolder extends Struct.CollectionTypeSchema {
+  collectionName: "upload_folders";
+  info: {
+    displayName: "Folder";
+    pluralName: "folders";
+    singularName: "folder";
+  };
+  options: {
+    draftAndPublish: false;
+  };
+  pluginOptions: {
+    "content-manager": {
+      visible: false;
+    };
+    "content-type-builder": {
+      visible: false;
+    };
+  };
+  attributes: {
+    children: Schema.Attribute.Relation<"oneToMany", "plugin::upload.folder">;
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+    files: Schema.Attribute.Relation<"oneToMany", "plugin::upload.file">;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      "oneToMany",
+      "plugin::upload.folder"
+    > &
+      Schema.Attribute.Private;
+    name: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
+    parent: Schema.Attribute.Relation<"manyToOne", "plugin::upload.folder">;
+    path: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
+    pathId: Schema.Attribute.Integer &
+      Schema.Attribute.Required &
+      Schema.Attribute.Unique;
+    publishedAt: Schema.Attribute.DateTime;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+  };
+}
+
+export interface PluginUsersPermissionsPermission
+  extends Struct.CollectionTypeSchema {
+  collectionName: "up_permissions";
+  info: {
+    description: "";
+    displayName: "Permission";
+    name: "permission";
+    pluralName: "permissions";
+    singularName: "permission";
+  };
+  options: {
+    draftAndPublish: false;
+  };
+  pluginOptions: {
+    "content-manager": {
+      visible: false;
+    };
+    "content-type-builder": {
+      visible: false;
+    };
+  };
+  attributes: {
+    action: Schema.Attribute.String & Schema.Attribute.Required;
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      "oneToMany",
+      "plugin::users-permissions.permission"
+    > &
+      Schema.Attribute.Private;
+    publishedAt: Schema.Attribute.DateTime;
+    role: Schema.Attribute.Relation<
+      "manyToOne",
+      "plugin::users-permissions.role"
+    >;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+  };
+}
+
+export interface PluginUsersPermissionsRole
+  extends Struct.CollectionTypeSchema {
+  collectionName: "up_roles";
+  info: {
+    description: "";
+    displayName: "Role";
+    name: "role";
+    pluralName: "roles";
+    singularName: "role";
+  };
+  options: {
+    draftAndPublish: false;
+  };
+  pluginOptions: {
+    "content-manager": {
+      visible: false;
+    };
+    "content-type-builder": {
+      visible: false;
+    };
+  };
+  attributes: {
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+    description: Schema.Attribute.String;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      "oneToMany",
+      "plugin::users-permissions.role"
+    > &
+      Schema.Attribute.Private;
+    name: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.SetMinMaxLength<{
+        minLength: 3;
+      }>;
+    permissions: Schema.Attribute.Relation<
+      "oneToMany",
+      "plugin::users-permissions.permission"
+    >;
+    publishedAt: Schema.Attribute.DateTime;
+    type: Schema.Attribute.String & Schema.Attribute.Unique;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+    users: Schema.Attribute.Relation<
+      "oneToMany",
+      "plugin::users-permissions.user"
+    >;
+  };
+}
+
+export interface PluginUsersPermissionsUser
+  extends Struct.CollectionTypeSchema {
+  collectionName: "up_users";
+  info: {
+    description: "";
+    displayName: "User";
+    name: "user";
+    pluralName: "users";
+    singularName: "user";
+  };
+  options: {
+    draftAndPublish: false;
+    timestamps: true;
+  };
+  attributes: {
+    blocked: Schema.Attribute.Boolean & Schema.Attribute.DefaultTo<false>;
+    confirmationToken: Schema.Attribute.String & Schema.Attribute.Private;
+    confirmed: Schema.Attribute.Boolean & Schema.Attribute.DefaultTo<false>;
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+    email: Schema.Attribute.Email &
+      Schema.Attribute.Required &
+      Schema.Attribute.SetMinMaxLength<{
+        minLength: 6;
+      }>;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      "oneToMany",
+      "plugin::users-permissions.user"
+    > &
+      Schema.Attribute.Private;
+    password: Schema.Attribute.Password &
+      Schema.Attribute.Private &
+      Schema.Attribute.SetMinMaxLength<{
+        minLength: 6;
+      }>;
+    provider: Schema.Attribute.String;
+    publishedAt: Schema.Attribute.DateTime;
+    resetPasswordToken: Schema.Attribute.String & Schema.Attribute.Private;
+    role: Schema.Attribute.Relation<
+      "manyToOne",
+      "plugin::users-permissions.role"
+    >;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+    username: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.Unique &
+      Schema.Attribute.SetMinMaxLength<{
+        minLength: 3;
+      }>;
   };
 }
 
 declare module "@strapi/strapi" {
   export module Public {
     export interface ContentTypeSchemas {
-      "plugin::upload.file": PluginUploadFile;
-      "plugin::upload.folder": PluginUploadFolder;
-      "plugin::i18n.locale": PluginI18NLocale;
-      "plugin::content-releases.release": PluginContentReleasesRelease;
-      "plugin::content-releases.release-action": PluginContentReleasesReleaseAction;
-      "plugin::review-workflows.workflow": PluginReviewWorkflowsWorkflow;
-      "plugin::review-workflows.workflow-stage": PluginReviewWorkflowsWorkflowStage;
-      "plugin::slugify.slug": PluginSlugifySlug;
-      "plugin::users-permissions.permission": PluginUsersPermissionsPermission;
-      "plugin::users-permissions.role": PluginUsersPermissionsRole;
-      "plugin::users-permissions.user": PluginUsersPermissionsUser;
+      "admin::api-token": AdminApiToken;
+      "admin::api-token-permission": AdminApiTokenPermission;
+      "admin::permission": AdminPermission;
+      "admin::role": AdminRole;
+      "admin::transfer-token": AdminTransferToken;
+      "admin::transfer-token-permission": AdminTransferTokenPermission;
+      "admin::user": AdminUser;
       "api::financial.currency-conversion": ApiFinancialCurrencyConversion;
       "api::geo.country": ApiGeoCountry;
       "api::geo.region": ApiGeoRegion;
@@ -1348,13 +1476,17 @@ declare module "@strapi/strapi" {
       "api::reporting.movement": ApiReportingMovement;
       "api::reporting.shipment": ApiReportingShipment;
       "api::team.member": ApiTeamMember;
-      "admin::permission": AdminPermission;
-      "admin::user": AdminUser;
-      "admin::role": AdminRole;
-      "admin::api-token": AdminApiToken;
-      "admin::api-token-permission": AdminApiTokenPermission;
-      "admin::transfer-token": AdminTransferToken;
-      "admin::transfer-token-permission": AdminTransferTokenPermission;
+      "plugin::content-releases.release": PluginContentReleasesRelease;
+      "plugin::content-releases.release-action": PluginContentReleasesReleaseAction;
+      "plugin::i18n.locale": PluginI18NLocale;
+      "plugin::review-workflows.workflow": PluginReviewWorkflowsWorkflow;
+      "plugin::review-workflows.workflow-stage": PluginReviewWorkflowsWorkflowStage;
+      "plugin::slugify.slug": PluginSlugifySlug;
+      "plugin::upload.file": PluginUploadFile;
+      "plugin::upload.folder": PluginUploadFolder;
+      "plugin::users-permissions.permission": PluginUsersPermissionsPermission;
+      "plugin::users-permissions.role": PluginUsersPermissionsRole;
+      "plugin::users-permissions.user": PluginUsersPermissionsUser;
     }
   }
 }


### PR DESCRIPTION
## What changed?

Added `beforeCreate` hook for the `needs` model to ensure we're not creating duplicates per https://github.com/distributeaid/aggregated-public-information/issues/53.

## How can you test this?
- [ ] Attempt to create a `need` in the Strapi admin panel with the same item, region, subregion, survey, and need as a preexisting need in the database and ensure it reports an error and doesn't save the duplicate
- [ ] Attempt to create a `need` in the Strapi admin panel as above, but changing one value to be unique (e.g. the need id) and ensure no error is reported and the record is saved