### PR TITLE
Feat/53/needs duplicate prevention

### DIFF
--- a/src/api/needs-assessment/content-types/need/lifecycles.ts
+++ b/src/api/needs-assessment/content-types/need/lifecycles.ts
@@ -1,0 +1,35 @@
+import { errors } from "@strapi/utils";
+export default {
+  async beforeCreate(event: any) {
+    const { data } = event.params;
+
+    // confirm each field is a valid entry of the correct content type
+    const regionId = data.region?.connect?.[0]?.id;
+    console.log(`regionId: ${regionId}`);
+    // look up the region associated with this id.
+    const region = await strapi
+      .documents("api::geo.region")
+      .findMany({ id: regionId });
+
+    console.log(`region: ${JSON.stringify(region)}`);
+
+    const subregionId = data.subregion?.connect?.[0]?.id ?? null;
+    const itemId = data.item?.connect[0]?.id ?? null;
+    const surveyId = data.survey?.connect[0]?.id ?? null;
+    const need = data.need;
+
+    const existingNeeds = await strapi
+      .documents("api::needs-assessment.need")
+      .findMany({
+        filters: {
+          region: regionId,
+          subregion: subregionId,
+          survey: surveyId,
+          item: itemId,
+        },
+      });
+    if (existingNeeds.length > 0) {
+      throw new errors.ApplicationError("Duplicate `need` entry found!");
+    }
+  },
+};

--- a/src/api/needs-assessment/content-types/need/lifecycles.ts
+++ b/src/api/needs-assessment/content-types/need/lifecycles.ts
@@ -1,35 +1,58 @@
 import { errors } from "@strapi/utils";
+
+const messagePrefix = "Cannot create needs-assessment.needs entry";
+
 export default {
   async beforeCreate(event: any) {
     const { data } = event.params;
 
-    // confirm each field is a valid entry of the correct content type
+    //NOTE: event.params.data appears to be using the original numeric id's for the related data, not the new documentId strings that Strapi recommends using in v5. So need to use findFirst() with filters instead of findOne() for the lookup. If Strapi fixes this, do we want to update to use the documentId's?
     const regionId = data.region?.connect?.[0]?.id;
-    console.log(`regionId: ${regionId}`);
-    // look up the region associated with this id.
-    const region = await strapi
-      .documents("api::geo.region")
-      .findMany({ id: regionId });
-
-    console.log(`region: ${JSON.stringify(region)}`);
-
+    const itemId = data.item?.connect[0]?.id;
+    const surveyId = data.survey?.connect[0]?.id;
     const subregionId = data.subregion?.connect?.[0]?.id ?? null;
-    const itemId = data.item?.connect[0]?.id ?? null;
-    const surveyId = data.survey?.connect[0]?.id ?? null;
-    const need = data.need;
 
-    const existingNeeds = await strapi
-      .documents("api::needs-assessment.need")
-      .findMany({
-        filters: {
-          region: regionId,
-          subregion: subregionId,
-          survey: surveyId,
-          item: itemId,
-        },
-      });
-    if (existingNeeds.length > 0) {
-      throw new errors.ApplicationError("Duplicate `need` entry found!");
+    const missingFields = [];
+    if (!surveyId) {
+      missingFields.push("survey");
     }
+
+    if (!regionId) {
+      missingFields.push("region");
+    }
+
+    if (!itemId) {
+      missingFields.push("item");
+    }
+
+    if (missingFields.length > 0) {
+      throw new errors.ApplicationError(
+        `${messagePrefix}. The following required fields are missing: ${missingFields.join(", ")}`,
+      );
+    }
+
+    await checkForDuplicates(surveyId, regionId, itemId, subregionId);
   },
 };
+
+async function checkForDuplicates(surveyId, regionId, itemId, subregionId) {
+  const filters = {
+    region: regionId,
+    survey: surveyId,
+    item: itemId,
+    subregion: subregionId ? subregionId : null,
+  };
+
+  const existingNeeds = await strapi
+    .documents("api::needs-assessment.need")
+    .findFirst({
+      populate: ["survey", "region", "item", "subregion"],
+      filters,
+    });
+
+  if (existingNeeds) {
+    throw new errors.ApplicationError(
+      `${messagePrefix}. An entry with this survey, region, subregion and item already exists!`,
+    );
+  }
+}

--- a/src/api/needs-assessment/content-types/need/schema.json
+++ b/src/api/needs-assessment/content-types/need/schema.json
@@ -29,7 +29,7 @@
       "relation": "oneToOne",
       "target": "api::product.item"
     },
-    "need": {
+    "amount": {
       "type": "integer",
       "required": true
     }

--- a/src/api/needs-assessment/content-types/need/schema.json
+++ b/src/api/needs-assessment/content-types/need/schema.json
@@ -12,12 +12,14 @@
       "type": "relation",
       "relation": "manyToOne",
       "target": "api::needs-assessment.survey",
-      "inversedBy": "needs"
+      "inversedBy": "needs",
+      "required": true
     },
     "region": {
       "type": "relation",
       "relation": "oneToOne",
-      "target": "api::geo.region"
+      "target": "api::geo.region",
+      "required": true
     },
     "subregion": {
       "type": "relation",
@@ -27,7 +29,8 @@
     "item": {
       "type": "relation",
       "relation": "oneToOne",
-      "target": "api::product.item"
+      "target": "api::product.item",
+      "required": true
     },
     "amount": {
       "type": "integer",

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -569,6 +569,7 @@ export interface ApiNeedsAssessmentNeed extends Struct.CollectionTypeSchema {
     draftAndPublish: false;
   };
   attributes: {
+    amount: Schema.Attribute.Integer & Schema.Attribute.Required;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
       Schema.Attribute.Private;
@@ -579,7 +580,6 @@ export interface ApiNeedsAssessmentNeed extends Struct.CollectionTypeSchema {
       "api::needs-assessment.need"
     > &
       Schema.Attribute.Private;
-    need: Schema.Attribute.Integer & Schema.Attribute.Required;
     publishedAt: Schema.Attribute.DateTime;
     region: Schema.Attribute.Relation<"oneToOne", "api::geo.region">;
     subregion: Schema.Attribute.Relation<"oneToOne", "api::geo.subregion">;

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -573,7 +573,8 @@ export interface ApiNeedsAssessmentNeed extends Struct.CollectionTypeSchema {
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
       Schema.Attribute.Private;
-    item: Schema.Attribute.Relation<"oneToOne", "api::product.item">;
+    item: Schema.Attribute.Relation<"oneToOne", "api::product.item"> &
+      Schema.Attribute.Required;
     locale: Schema.Attribute.String & Schema.Attribute.Private;
     localizations: Schema.Attribute.Relation<
       "oneToMany",
@@ -581,12 +582,14 @@ export interface ApiNeedsAssessmentNeed extends Struct.CollectionTypeSchema {
     > &
       Schema.Attribute.Private;
     publishedAt: Schema.Attribute.DateTime;
-    region: Schema.Attribute.Relation<"oneToOne", "api::geo.region">;
+    region: Schema.Attribute.Relation<"oneToOne", "api::geo.region"> &
+      Schema.Attribute.Required;
     subregion: Schema.Attribute.Relation<"oneToOne", "api::geo.subregion">;
     survey: Schema.Attribute.Relation<
       "manyToOne",
       "api::needs-assessment.survey"
-    >;
+    > &
+      Schema.Attribute.Required;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
       Schema.Attribute.Private;


### PR DESCRIPTION
## What changed?
Confirms that the required related fields (survey, region and item) are included
Checks for any existing entries with the same values for survey, region, subregion and item
Throws an error if duplicate entry is found and does not create the entry.
 
<!-- include a link to a GitHub issue, if applicable -->
Closes #53 

## How can you test this?
Currently there are no automated tests. Best way to test is by sending post requests via an http client (e.g. [Bruno](https://www.usebruno.com/), Postman, Insomnia). 

1. If your local db is empty, using the Content Manager, add several entries in the `Survey`, `Region`, `Subregion` and `Item` collections. Use the Id's from these items in the "connect" parts of the body data listed below.  
1. Use the following api for the remaining steps
   Request type: `POST`
   Request url:  `http://localhost:1337/api/needs?populate=*`

2. Create a post body that successfully creates an entry. 
```js
{
  "data": {
    "amount": 1,
    "survey": {
      "disconnect": [],
      "connect":[1]
    },
    "region": {
      "connect": [1]
    },
    "item": {
        "connect": [1]
    }
  }
}
```

4. Send that same post again and confirm that it returns an error and does not create a duplicate entry

5. Send a post request that is missing one or more required fields. Confirm that this returns an error and does not create an entry. For example, this one does not have a `survey` field:

   ```js
   {
     "data": {
       "amount": 1,
       "region": {
         "connect": [1]
       },
       "item": {
           "connect": [1]
       }
     }
   }
   ```

6. Send a post that has invalid ids for related data. Confirm that this returns an error and does not create an entry

   ```js
   {
     "data": {
       "amount": 1,
       "survey": {
         "disconnect": [],
         "connect":[999]
       },
       "region": {
         "connect": [999]
       },
       "item": {
           "connect": [999]
       }
     }
   }
   ```

