### PR TITLE
feat: added `yearQuarter` field to `NeedsAssessment.Survey`

### DIFF
--- a/src/api/needs-assessment/content-types/survey/schema.json
+++ b/src/api/needs-assessment/content-types/survey/schema.json
@@ -18,7 +18,12 @@
     },
     "quarter": {
       "type": "enumeration",
-      "enum": ["Q1", "Q2", "Q3", "Q4"],
+      "enum": [
+        "Q1",
+        "Q2",
+        "Q3",
+        "Q4"
+      ],
       "required": true
     },
     "needs": {
@@ -26,6 +31,9 @@
       "relation": "oneToMany",
       "target": "api::needs-assessment.need",
       "mappedBy": "needs_assessment_survey"
+    },
+    "yearQuarter": {
+      "type": "string"
     }
   }
 }

--- a/src/api/needs-assessment/content-types/survey/schema.json
+++ b/src/api/needs-assessment/content-types/survey/schema.json
@@ -18,12 +18,7 @@
     },
     "quarter": {
       "type": "enumeration",
-      "enum": [
-        "Q1",
-        "Q2",
-        "Q3",
-        "Q4"
-      ],
+      "enum": ["Q1", "Q2", "Q3", "Q4"],
       "required": true
     },
     "needs": {

--- a/src/api/needs-assessment/controllers/survey.ts
+++ b/src/api/needs-assessment/controllers/survey.ts
@@ -3,5 +3,18 @@
  */
 
 import { factories } from "@strapi/strapi";
+import { processSurvey } from "../../../functions/content-types/needs-assessment/survey";
 
-export default factories.createCoreController("api::needs-assessment.survey");
+export default factories.createCoreController(
+  "api::needs-assessment.survey",
+  ({ strapi: _strapi }) => ({
+    async create(ctx) {
+      ctx.request.body.data = processSurvey(ctx.request.body.data);
+      return super.create(ctx);
+    },
+    async update(ctx) {
+      ctx.request.body.data = processSurvey(ctx.request.body.data);
+      return super.create(ctx);
+    },
+  }),
+);

--- a/src/functions/content-types/index.ts
+++ b/src/functions/content-types/index.ts
@@ -1,6 +1,7 @@
 import { processProductItem } from "./product/item";
 import { processGroup } from "./group/group";
 import { processReportingCargo } from "./reporting/cargo";
+import { processSurvey } from "./needs-assessment/survey";
 
 export function processContentType(path, data) {
   /*
@@ -11,6 +12,7 @@ export function processContentType(path, data) {
     "product.item": processProductItem,
     "group.group": processGroup,
     "reporting.cargo": processReportingCargo,
+    "needs-assessment.survey": processSurvey,
   };
 
   const contentType = detectContentType(path);

--- a/src/functions/content-types/needs-assessment/survey.test.ts
+++ b/src/functions/content-types/needs-assessment/survey.test.ts
@@ -1,0 +1,15 @@
+import { processSurvey } from "./survey";
+
+describe("processSurvey", () => {
+  it("creates yearQuarter field", () => {
+    const survey = { year: "2024", quarter: "Q1", needs: {} };
+    const expected = {
+      year: "2024",
+      quarter: "Q1",
+      yearQuearter: "2024 - Q1",
+      needs: {},
+    };
+    const actual = processSurvey(survey);
+    expect(actual).toEqual(expected);
+  });
+});

--- a/src/functions/content-types/needs-assessment/survey.test.ts
+++ b/src/functions/content-types/needs-assessment/survey.test.ts
@@ -6,7 +6,7 @@ describe("processSurvey", () => {
     const expected = {
       year: "2024",
       quarter: "Q1",
-      yearQuearter: "2024 - Q1",
+      yearQuarter: "2024-Q1",
       needs: {},
     };
     const actual = processSurvey(survey);

--- a/src/functions/content-types/needs-assessment/survey.ts
+++ b/src/functions/content-types/needs-assessment/survey.ts
@@ -1,0 +1,6 @@
+export function processSurvey(data: { year: string; quarter: string }) {
+  return {
+    ...data,
+    yearQuarter: `${data.year} - ${data.quarter}`,
+  };
+}

--- a/src/functions/content-types/needs-assessment/survey.ts
+++ b/src/functions/content-types/needs-assessment/survey.ts
@@ -1,6 +1,6 @@
 export function processSurvey(data: { year: string; quarter: string }) {
   return {
     ...data,
-    yearQuarter: `${data.year} - ${data.quarter}`,
+    yearQuarter: `${data.year}-${data.quarter}`,
   };
 }

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -732,6 +732,7 @@ export interface ApiNeedsAssessmentSurvey extends Struct.CollectionTypeSchema {
     updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
       Schema.Attribute.Private;
     year: Schema.Attribute.String & Schema.Attribute.Required;
+    yearQuarter: Schema.Attribute.String;
   };
 }
 


### PR DESCRIPTION
## What changed?

Added `yearQuarter` field to `NeedsAssessment.Survey` per https://github.com/distributeaid/aggregated-public-information/issues/191

## How can you test this?

- [x] Unit tests
- [ ] Integration/end-to-end tests
- [x] Manual tests

Making this a draft until testing is more fleshed out