### PR TITLE
feat(data-ingestion): Upload product items from the needs data to the Strapi collection

### DIFF
--- a/src/api/product/content-types/item/schema.json
+++ b/src/api/product/content-types/item/schema.json
@@ -4,9 +4,12 @@
   "info": {
     "singularName": "item",
     "pluralName": "items",
-    "displayName": "Product.Item"
+    "displayName": "Product.Item",
+    "description": ""
   },
-  "options": {},
+  "options": {
+    "draftAndPublish": false
+  },
   "attributes": {
     "name": {
       "type": "string",
@@ -54,6 +57,9 @@
       "default": 1,
       "required": true,
       "min": 1
+    },
+    "unit": {
+      "type": "string"
     }
   }
 }

--- a/src/scripts/import-needs-assessment-data/add-categories.ts
+++ b/src/scripts/import-needs-assessment-data/add-categories.ts
@@ -190,7 +190,10 @@ async function getCategory({
     data,
     orig,
     status,
-    logs: [...logs, "Success: Product.Category does not already exist. Proceed to upload category."],
+    logs: [
+      ...logs,
+      "Success: Product.Category does not already exist. Proceed to upload category.",
+    ],
   };
 }
 

--- a/src/scripts/import-needs-assessment-data/add-categories.ts
+++ b/src/scripts/import-needs-assessment-data/add-categories.ts
@@ -1,0 +1,34 @@
+import { STRAPI_ENV } from "../strapi-env";
+import {
+  Category,
+  NeedAssessment,
+  CategoryUploadWorkflow,
+  UploadWorkflowStatus,
+  CategoryUploadWorkflowResults,
+} from "./types.d";
+
+/*  Add Categories from Needs Assessment Data
+ * ------------------------------------------------------- */
+export function consolidateCategories(data: NeedAssessment[]): string[] {
+    const categories = data.reduce((acc: string[], item) => {
+      const category = item.product.category;
+      if (category && !acc.includes(category)) {
+        acc.push(category);
+      }
+      return acc;
+    }, []);
+  
+    return categories;
+  }
+
+/*  Consolidate Categories
+ * ------------------------------------------------------- */
+
+/*  Parse Category
+ * ------------------------------------------------------- */
+
+/*  Get Category
+ * ------------------------------------------------------- */
+
+/*  Upload Category
+ * ------------------------------------------------------- */

--- a/src/scripts/import-needs-assessment-data/add-categories.ts
+++ b/src/scripts/import-needs-assessment-data/add-categories.ts
@@ -19,25 +19,25 @@ export async function addCategories(
 
   const results = await Promise.allSettled<CategoryUploadWorkflow>(
     uniqueCategories.map((category) => {
-        const initialWorkflow = {
-          data: {
-            category,
-          },
-          orig: category,
-          status: UploadWorkflowStatus.PROCESSING,
-          logs: [],
-        };
+      const initialWorkflow = {
+        data: {
+          category,
+        },
+        orig: category,
+        status: UploadWorkflowStatus.PROCESSING,
+        logs: [],
+      };
 
-        return Promise.resolve(initialWorkflow)
-          .then(parseCategory)
-          .then(getCategory)
-          .then(uploadCategory);
-    })
+      return Promise.resolve(initialWorkflow)
+        .then(parseCategory)
+        .then(getCategory)
+        .then(uploadCategory);
+    }),
   );
 
   // { "SUCCESS": [], "ALREADY_EXITS": [], ...}
   const resultsMap: CategoryUploadWorkflowResults = Object.fromEntries(
-    Object.keys(UploadWorkflowStatus).map((key) => [key, []])
+    Object.keys(UploadWorkflowStatus).map((key) => [key, []]),
   ) as CategoryUploadWorkflowResults;
 
   results.forEach((result) => {
@@ -159,7 +159,7 @@ async function getCategory({
 
   // log strapi response status
   //console.log("Strapi response status:", response.status);
-  
+
   const matchingCategory = body.data.find(
     (category) => category.name.toLowerCase() === data.category.toLowerCase(),
   );

--- a/src/scripts/import-needs-assessment-data/add-categories.ts
+++ b/src/scripts/import-needs-assessment-data/add-categories.ts
@@ -165,7 +165,6 @@ async function getCategory({
   );
 
   if (!response.ok) {
-    console.log("Non-ok response");
     throw {
       data,
       orig,

--- a/src/scripts/import-needs-assessment-data/add-categories.ts
+++ b/src/scripts/import-needs-assessment-data/add-categories.ts
@@ -9,23 +9,55 @@ import {
 
 /*  Add Categories from Needs Assessment Data
  * ------------------------------------------------------- */
-export function consolidateCategories(data: NeedAssessment[]): string[] {
-    const categories = data.reduce((acc: string[], item) => {
-      const category = item.product.category;
-      if (category && !acc.includes(category)) {
-        acc.push(category);
-      }
-      return acc;
-    }, []);
-  
-    return categories;
-  }
 
 /*  Consolidate Categories
  * ------------------------------------------------------- */
+export function consolidateCategories(data: NeedAssessment[]): string[] {
+  const categories = data.reduce((acc: string[], item) => {
+    const category = item.product.category;
+    if (category && !acc.includes(category)) {
+      acc.push(category);
+    }
+    return acc;
+  }, []);
+
+  return categories;
+}
 
 /*  Parse Category
  * ------------------------------------------------------- */
+function parseCategory({
+  data,
+  orig,
+  status,
+  logs,
+}: CategoryUploadWorkflow): CategoryUploadWorkflow {
+  logs = [...logs, `Log: parsing category "${orig}"`];
+
+  if (orig == null || typeof orig !== "string") {
+    throw {
+      data,
+      orig,
+      status: UploadWorkflowStatus.ORIGINAL_DATA_INVALID,
+      logs: [
+        ...logs,
+        `Error: Invalid category input: "${orig}". Expected a non-null value.`,
+      ],
+    };
+  }
+
+  const newData = {
+    ...data,
+    category: orig,
+  };
+
+  return {
+    data: newData,
+    orig,
+    status,
+    logs,
+  };
+}
 
 /*  Get Category
  * ------------------------------------------------------- */

--- a/src/scripts/import-needs-assessment-data/add-categories.ts
+++ b/src/scripts/import-needs-assessment-data/add-categories.ts
@@ -116,3 +116,44 @@ export async function getCategory({
 
 /*  Upload Category
  * ------------------------------------------------------- */
+export async function uploadCategory({
+  data,
+  orig,
+  /* status, */ logs,
+}: CategoryUploadWorkflow): Promise<CategoryUploadWorkflow> {
+  logs = [...logs, `Log: Creating Product.Category "${orig}".`];
+
+  const response = await fetch(`${STRAPI_ENV.URL}/categories`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${STRAPI_ENV.KEY}`,
+    },
+    body: JSON.stringify({
+      data: {
+        name: data.category,
+      },
+    }),
+  });
+  const body = await response.json();
+
+  if (!response.ok) {
+    throw {
+      data,
+      orig,
+      status: UploadWorkflowStatus.UPLOAD_ERROR,
+      logs: [
+        ...logs,
+        `Error: Failed to create Product.Category. HttpStatus: ${response.status} - ${response.statusText}`,
+        JSON.stringify(body),
+      ],
+    };
+  }
+
+  return {
+    data: body.data,
+    orig,
+    status: UploadWorkflowStatus.SUCCESS,
+    logs: [...logs, "Success: Created Product.Category."],
+  };
+}

--- a/src/scripts/import-needs-assessment-data/add-categories.ts
+++ b/src/scripts/import-needs-assessment-data/add-categories.ts
@@ -1,9 +1,9 @@
 import { STRAPI_ENV } from "../strapi-env";
+import { UploadWorkflowStatus } from "../statusCodes";
 import {
   Category,
   NeedAssessment,
   CategoryUploadWorkflow,
-  UploadWorkflowStatus,
   CategoryUploadWorkflowResults,
 } from "./types.d";
 

--- a/src/scripts/import-needs-assessment-data/add-categories.ts
+++ b/src/scripts/import-needs-assessment-data/add-categories.ts
@@ -190,7 +190,7 @@ async function getCategory({
     data,
     orig,
     status,
-    logs: [...logs, "Success: Confirmed Product.Category does not exist."],
+    logs: [...logs, "Success: Product.Category does not already exist. Proceed to upload category."],
   };
 }
 

--- a/src/scripts/import-needs-assessment-data/add-categories.ts
+++ b/src/scripts/import-needs-assessment-data/add-categories.ts
@@ -9,7 +9,9 @@ import {
 
 /*  Add Categories from Needs Assessment Data
  * ------------------------------------------------------- */
-export async function addCategories(data: NeedAssessment[]): Promise<Category[]> {
+export async function addCategories(
+  data: NeedAssessment[],
+): Promise<Category[]> {
   console.log("Adding Product.Categories from the Needs Assessment data ...");
 
   const uniqueCategories = consolidateCategories(data);
@@ -151,7 +153,10 @@ async function getCategory({
   status,
   logs,
 }: CategoryUploadWorkflow): Promise<CategoryUploadWorkflow> {
-  logs = [...logs, `Log: Checking if Product.Category "${orig}" already exists.`];
+  logs = [
+    ...logs,
+    `Log: Checking if Product.Category "${orig}" already exists.`,
+  ];
 
   //Fetch the data from Strapi
   const response = await fetch(`${STRAPI_ENV.URL}/categories`, {

--- a/src/scripts/import-needs-assessment-data/add-categories.ts
+++ b/src/scripts/import-needs-assessment-data/add-categories.ts
@@ -99,15 +99,16 @@ const _isRejected = <T>(
 /*  Consolidate Categories
  * ------------------------------------------------------- */
 function consolidateCategories(data: NeedAssessment[]): string[] {
-  const categories = data.reduce((acc: string[], item) => {
-    const category = item.product.category;
-    if (category && !acc.includes(category)) {
-      acc.push(category);
-    }
-    return acc;
-  }, []);
+  const categories = new Set<string>();
 
-  return categories;
+  data.forEach((item) => {
+    const category = item.product.category;
+    if (category && category !== null) {
+      categories.add(category);
+    }
+  });
+
+  return Array.from(categories);
 }
 
 /*  Parse Category

--- a/src/scripts/import-needs-assessment-data/add-items.ts
+++ b/src/scripts/import-needs-assessment-data/add-items.ts
@@ -104,14 +104,17 @@ export function consolidateProductsByCategory(
   });
 
   // Remove duplicates before further processing
-  const uniqueProducts = consolidatedProducts.filter((product, index, self) =>
-      index === self.findIndex(p => 
-        p.item === product.item &&
-        p.category === product.category &&
-        p.ageGender === product.ageGender &&
-        p.sizeStyle === product.sizeStyle
-      )
-    );
+  const uniqueProducts = consolidatedProducts.filter(
+    (product, index, self) =>
+      index ===
+      self.findIndex(
+        (p) =>
+          p.item === product.item &&
+          p.category === product.category &&
+          p.ageGender === product.ageGender &&
+          p.sizeStyle === product.sizeStyle,
+      ),
+  );
 
   // Print category counts after processing the data
   const categoryCounts = {};
@@ -137,7 +140,6 @@ async function parseProducts({
   logs = [...logs, `Log: parsing products...`];
   // console.log("👉🏻 This is the data coming into the parse function:", data);
   return new Promise<ProductUploadWorkflow>((resolve, _reject) => {
-  
     const parsedData: Product[] = [];
     if (typeof data === "object" && data !== null) {
       // Check if data contains a 'product' property
@@ -173,8 +175,7 @@ async function parseProducts({
       status,
       logs,
     });
-  })
-
+  });
 }
 
 /* Get Category Ids */
@@ -184,8 +185,11 @@ async function getCategoryIds({
   status,
   logs,
 }: ProductUploadWorkflow): Promise<ProductUploadWorkflow> {
-  logs = [...logs, `Log: Getting the category Id for "${data[0].item} // ${data[0].category} // ${data[0].ageGender} // ${data[0].sizeStyle}".`];
-  
+  logs = [
+    ...logs,
+    `Log: Getting the category Id for "${data[0].item} // ${data[0].category} // ${data[0].ageGender} // ${data[0].sizeStyle}".`,
+  ];
+
   const response = await fetch(`${STRAPI_ENV.URL}/categories`, {
     method: "GET",
     headers: {
@@ -202,9 +206,7 @@ async function getCategoryIds({
   const categoryResults = await response.json();
   const matchingCategory = categoryResults.data.find((category) => {
     const parsedItem = data[0];
-    return (
-      category.name.toLowerCase() === parsedItem.category.toLowerCase()
-    );
+    return category.name.toLowerCase() === parsedItem.category.toLowerCase();
   });
 
   if (!response.ok) {
@@ -224,16 +226,19 @@ async function getCategoryIds({
   if (matchingCategory) {
     const updateProduct = {
       ...data[0],
-      categoryId: matchingCategory.id
+      categoryId: matchingCategory.id,
     };
-    data[0] = updateProduct
+    data[0] = updateProduct;
   }
 
   return {
     data,
     orig,
     status,
-    logs: [...logs, "Success: Confirmed Product.Item has a matching category Id."],
+    logs: [
+      ...logs,
+      "Success: Confirmed Product.Item has a matching category Id.",
+    ],
   };
 }
 
@@ -245,32 +250,39 @@ async function getProduct({
   status,
   logs,
 }: ProductUploadWorkflow): Promise<ProductUploadWorkflow> {
-  logs = [...logs, `Log: Checking if "${data[0].item} // ${data[0].category} // ${data[0].ageGender} // ${data[0].sizeStyle}" already exists.`];
+  logs = [
+    ...logs,
+    `Log: Checking if "${data[0].item} // ${data[0].category} // ${data[0].ageGender} // ${data[0].sizeStyle}" already exists.`,
+  ];
 
   // Queries to fetch the data from Strapi
   const query = qs.stringify({
     filters: {
-      $or: data.map(item => ({
+      $or: data.map((item) => ({
         name: { $eq: item.item },
         category: { name: { $eq: item.category } },
         age_gender: { $eq: item.ageGender },
-        size_style: { $eq: item.sizeStyle }
-      }))
+        size_style: { $eq: item.sizeStyle },
+      })),
     },
   });
 
-  const response = await fetch(`${STRAPI_ENV.URL}/items?populate=category&${query}`, {
-    method: "GET",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${STRAPI_ENV.KEY}`,
+  const response = await fetch(
+    `${STRAPI_ENV.URL}/items?populate=category&${query}`,
+    {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${STRAPI_ENV.KEY}`,
+      },
     },
-  });
+  );
 
   const body = await response.json();
 
-  logs = [...logs,
-    `Log: Found ${body.data.length} matching items from ${data.length} queries.`
+  logs = [
+    ...logs,
+    `Log: Found ${body.data.length} matching items from ${data.length} queries.`,
   ];
 
   // log strapi response status
@@ -297,7 +309,7 @@ async function getProduct({
       orig,
       status: UploadWorkflowStatus.ALREADY_EXISTS,
       logs: [...logs, "Log: Found existing item. Skipping ...."],
-    }
+    };
   }
 
   return {
@@ -316,7 +328,10 @@ async function uploadProduct({
   /*status, */
   logs,
 }: ProductUploadWorkflow): Promise<ProductUploadWorkflow> {
-  logs = [...logs, `Log: Creating item "${data[0].item} // ${data[0].category} // ${data[0].ageGender} // ${data[0].sizeStyle}".`];
+  logs = [
+    ...logs,
+    `Log: Creating item "${data[0].item} // ${data[0].category} // ${data[0].ageGender} // ${data[0].sizeStyle}".`,
+  ];
 
   const response = await fetch(`${STRAPI_ENV.URL}/items`, {
     method: "POST",
@@ -324,11 +339,11 @@ async function uploadProduct({
       "Content-Type": "application/json",
       Authorization: `Bearer ${STRAPI_ENV.KEY}`,
     },
-    body: JSON.stringify({ 
+    body: JSON.stringify({
       data: {
         name: data[0].item,
         category: {
-          id: data[0].categoryId
+          id: data[0].categoryId,
         },
         age_gender: data[0].ageGender,
         size_style: data[0].sizeStyle,

--- a/src/scripts/import-needs-assessment-data/add-items.ts
+++ b/src/scripts/import-needs-assessment-data/add-items.ts
@@ -42,11 +42,7 @@ export function consolidateProductsByCategory(
 
 /*  Parse Products
  * ------------------------------------------------------- */
-export function parseProducts(
-  data: Product[],
-  orig,
-  status,
-): ProductUploadWorkflow {
+export function parseProducts(data: Product[], orig, _status): ProductUploadWorkflow {
   const logs = [];
   logs.push(`Parsing products ...`);
 
@@ -57,24 +53,24 @@ export function parseProducts(
     data.forEach((item: Product) => {
       logs.push(`Parsing product: ${item.item}`);
 
-      if (!item.category || !item.item || !item.unit) {
-        problematicItems.push(item);
-      } else {
-        const processedProduct: Product = {
-          ...item,
-          parsed: true,
-        };
-        parsedData.push(processedProduct);
-      }
-    });
+    if (!item.category || !item.item || !item.unit) {
+      problematicItems.push(item);
+    } else {
+      const processedProduct: Product = {
+        ...item,
+      };
+      parsedData.push(processedProduct);
+    }
+
+  });
   } else {
     console.log("Data property is not an array");
   }
 
   const hasProblematicItems = problematicItems.length > 0;
   const updatedStatus = hasProblematicItems
-    ? UploadWorkflowStatus.ORIGINAL_DATA_INVALID
-    : UploadWorkflowStatus.SUCCESS;
+  ? UploadWorkflowStatus.PROCESSING
+  : UploadWorkflowStatus.SUCCESS
 
   logs.push(
     `Workflow completed. Status: ${problematicItems.length} product items were problematic: ${JSON.stringify(problematicItems, null, 2).replace(/\\n|"/g, "")}`,

--- a/src/scripts/import-needs-assessment-data/add-items.ts
+++ b/src/scripts/import-needs-assessment-data/add-items.ts
@@ -9,9 +9,7 @@ import {
 
 /*  Add Products from Needs Assessment Data
  * ------------------------------------------------------- */
-export async function addProducts(
-  data: NeedAssessment[],
-): Promise<Product[]> {
+export async function addProducts(data: NeedAssessment[]): Promise<Product[]> {
   console.log("Adding Product.Items from the Needs Assessment data ...");
 
   const uniqueProducts = consolidateProductsByCategory(data);
@@ -27,10 +25,9 @@ export async function addProducts(
         logs: [],
       };
 
-      return Promise.resolve(initialWorkflow)
-        .then(parseProducts)
-        // .then(getCategory)
-        // .then(uploadCategory);
+      return Promise.resolve(initialWorkflow).then(parseProducts);
+      // .then(getCategory)
+      // .then(uploadCategory);
     }),
   );
 
@@ -118,7 +115,7 @@ export function consolidateProductsByCategory(
 /*  Parse Products
  * ------------------------------------------------------- */
 export function parseProducts({
-  data, 
+  data,
   orig,
   status,
   logs,
@@ -128,10 +125,10 @@ export function parseProducts({
 
   const parsedData: Product[] = [];
 
-  if (typeof data === 'object' && data !== null) {
+  if (typeof data === "object" && data !== null) {
     // Check if data contains a 'product' property
-    if ('product' in data) {
-      const product = (data.product as Product);
+    if ("product" in data) {
+      const product = data.product as Product;
 
       logs.push(`Parsing product: ${product.item}`);
 
@@ -152,7 +149,7 @@ export function parseProducts({
         parsedData.push(processedProduct);
       }
     } else {
-    console.log("unexpected object structure:", JSON.stringify(data));
+      console.log("unexpected object structure:", JSON.stringify(data));
     }
   }
 

--- a/src/scripts/import-needs-assessment-data/add-items.ts
+++ b/src/scripts/import-needs-assessment-data/add-items.ts
@@ -203,7 +203,6 @@ async function getCategoryIds({
   });
 
   if (!response.ok) {
-    console.log(response);
     throw new Error(`HTTP error! Status: ${response.status}`);
   }
 

--- a/src/scripts/import-needs-assessment-data/add-items.ts
+++ b/src/scripts/import-needs-assessment-data/add-items.ts
@@ -42,38 +42,43 @@ export function consolidateProductsByCategory(
 
 /*  Parse Products
  * ------------------------------------------------------- */
-export function parseProducts(data: Product[], orig, status): ProductUploadWorkflow {
+export function parseProducts(
+  data: Product[],
+  orig,
+  status,
+): ProductUploadWorkflow {
   const logs = [];
   logs.push(`Parsing products ...`);
-  
+
   const parsedData: Product[] = [];
   const problematicItems: Product[] = [];
 
   if (Array.isArray(data)) {
-  data.forEach((item: Product) => {
-    logs.push(`Parsing product: ${item.item}`);
+    data.forEach((item: Product) => {
+      logs.push(`Parsing product: ${item.item}`);
 
-    if (!item.category || !item.item || !item.unit) {
-      problematicItems.push(item);
-    } else {
-      const processedProduct: Product = {
-        ...item,
-        parsed: true
-      };
-      parsedData.push(processedProduct);
-    }
-
-  });
+      if (!item.category || !item.item || !item.unit) {
+        problematicItems.push(item);
+      } else {
+        const processedProduct: Product = {
+          ...item,
+          parsed: true,
+        };
+        parsedData.push(processedProduct);
+      }
+    });
   } else {
     console.log("Data property is not an array");
   }
 
   const hasProblematicItems = problematicItems.length > 0;
   const updatedStatus = hasProblematicItems
-  ? UploadWorkflowStatus.ORIGINAL_DATA_INVALID
-  : UploadWorkflowStatus.SUCCESS
+    ? UploadWorkflowStatus.ORIGINAL_DATA_INVALID
+    : UploadWorkflowStatus.SUCCESS;
 
-  logs.push(`Workflow completed. Status: ${problematicItems.length} product items were problematic: ${JSON.stringify(problematicItems, null, 2).replace(/\\n|"/g, '')}`);
+  logs.push(
+    `Workflow completed. Status: ${problematicItems.length} product items were problematic: ${JSON.stringify(problematicItems, null, 2).replace(/\\n|"/g, "")}`,
+  );
   // console.log(problematicItems)
 
   return {

--- a/src/scripts/import-needs-assessment-data/add-items.ts
+++ b/src/scripts/import-needs-assessment-data/add-items.ts
@@ -42,7 +42,11 @@ export function consolidateProductsByCategory(
 
 /*  Parse Products
  * ------------------------------------------------------- */
-export function parseProducts(data: Product[], orig, _status): ProductUploadWorkflow {
+export function parseProducts(
+  data: Product[],
+  orig,
+  _status,
+): ProductUploadWorkflow {
   const logs = [];
   logs.push(`Parsing products ...`);
 
@@ -53,24 +57,23 @@ export function parseProducts(data: Product[], orig, _status): ProductUploadWork
     data.forEach((item: Product) => {
       logs.push(`Parsing product: ${item.item}`);
 
-    if (!item.category || !item.item || !item.unit) {
-      problematicItems.push(item);
-    } else {
-      const processedProduct: Product = {
-        ...item,
-      };
-      parsedData.push(processedProduct);
-    }
-
-  });
+      if (!item.category || !item.item || !item.unit) {
+        problematicItems.push(item);
+      } else {
+        const processedProduct: Product = {
+          ...item,
+        };
+        parsedData.push(processedProduct);
+      }
+    });
   } else {
     console.log("Data property is not an array");
   }
 
   const hasProblematicItems = problematicItems.length > 0;
   const updatedStatus = hasProblematicItems
-  ? UploadWorkflowStatus.PROCESSING
-  : UploadWorkflowStatus.SUCCESS
+    ? UploadWorkflowStatus.PROCESSING
+    : UploadWorkflowStatus.SUCCESS;
 
   logs.push(
     `Workflow completed. Status: ${problematicItems.length} product items were problematic: ${JSON.stringify(problematicItems, null, 2).replace(/\\n|"/g, "")}`,

--- a/src/scripts/import-needs-assessment-data/add-items.ts
+++ b/src/scripts/import-needs-assessment-data/add-items.ts
@@ -30,7 +30,7 @@ export async function addProducts(data: NeedAssessment[]): Promise<Product[]> {
         .then(parseProducts)
         .then(getCategoryIds)
         .then(getProduct)
-        // .then(uploadProduct);
+        .then(uploadProduct);
     }),
   );
 
@@ -51,7 +51,6 @@ export async function addProducts(data: NeedAssessment[]): Promise<Product[]> {
 
     // NOTE: uncomment & set the status key to debug different types of results
     // if (key !== UploadWorkflowStatus.SUCCESS && key !== UploadWorkflowStatus.ALREADY_EXISTS) {
-    // if (key !== UploadWorkflowStatus.ALREADY_EXISTS) {
     //   resultsMap[key].forEach((result) => {
     //     console.log(result)
     //     console.log("\n")
@@ -176,7 +175,6 @@ async function getCategoryIds({
 }: ProductUploadWorkflow): Promise<ProductUploadWorkflow> {
   logs = [...logs, `Log: Getting the category Id for "${data[0].item} // ${data[0].category} // ${data[0].ageGender} // ${data[0].sizeStyle}".`];
   
-  // console.log(`    - getting existing categories from ${STRAPI_ENV.URL}`);
   const response = await fetch(`${STRAPI_ENV.URL}/categories`, {
     method: "GET",
     headers: {
@@ -307,7 +305,7 @@ async function uploadProduct({
   /*status, */
   logs,
 }: ProductUploadWorkflow): Promise<ProductUploadWorkflow> {
-  logs = [...logs, `Log: Creating Product.Item "${data[0].item} // ${data[0].category} // ${data[0].ageGender} // ${data[0].sizeStyle}".`];
+  logs = [...logs, `Log: Creating item "${data[0].item} // ${data[0].category} // ${data[0].ageGender} // ${data[0].sizeStyle}".`];
 
   const response = await fetch(`${STRAPI_ENV.URL}/items`, {
     method: "POST",
@@ -319,7 +317,7 @@ async function uploadProduct({
       data: {
         name: data[0].item,
         category: {
-          name: data[0].category
+          id: data[0].categoryId
         },
         age_gender: data[0].ageGender,
         size_style: data[0].sizeStyle,

--- a/src/scripts/import-needs-assessment-data/add-items.ts
+++ b/src/scripts/import-needs-assessment-data/add-items.ts
@@ -1,0 +1,45 @@
+import { STRAPI_ENV } from "../strapi-env";
+import {
+  Product,
+  NeedAssessment,
+//   ProductUploadWorkflow,
+//   UploadWorkflowStatus,
+//   ProductUploadWorkflowResults,
+} from "./types.d";
+
+/*  Consolidate Products in each Category
+ * ------------------------------------------------------- */
+export function consolidateProductsByCategory(data: NeedAssessment[]): Record<string, Product[]> {
+    const consolidatedProducts: Record<string, Product[]> = {};
+    const categoryCounts: Record<string, number> = {};
+
+    data.forEach(assessment => {
+        const category = assessment.product.category;
+
+        if (!consolidatedProducts[category]) {
+            consolidatedProducts[category] = [];
+            categoryCounts[category] = 0;
+        }
+
+        const productItem = assessment.product.item;
+
+        // Only add the item if it's not empty or undefined
+        if (productItem) {
+            consolidatedProducts[category].push({
+                category: category,
+                item: productItem,
+                ageGender: assessment.product.ageGender || '',
+                sizeStyle: assessment.product.sizeStyle || '',
+                unit: assessment.product.unit || ''
+            });
+            categoryCounts[category]++;
+        }
+    });
+
+    // Print category counts after processing the data
+    Object.entries(categoryCounts).forEach(([category, count]) => {
+        console.log(`${category} has ${count} products`);
+    });
+
+    return consolidatedProducts;
+}

--- a/src/scripts/import-needs-assessment-data/add-items.ts
+++ b/src/scripts/import-needs-assessment-data/add-items.ts
@@ -105,12 +105,12 @@ export function consolidateProductsByCategory(
   const uniqueProductSet = new Set<string>();
   const uniqueProducts: Product[] = [];
 
-  consolidatedProducts.forEach(product => {
+  consolidatedProducts.forEach((product) => {
     const productKey = JSON.stringify([
       product.item,
       product.category,
       product.ageGender,
-      product.sizeStyle
+      product.sizeStyle,
     ]);
 
     if (!uniqueProductSet.has(productKey)) {
@@ -324,7 +324,10 @@ async function getProduct({
     data,
     orig,
     status,
-    logs: [...logs, "Success: Confirmed Product.Item does not already exist. Proceed to upload product."],
+    logs: [
+      ...logs,
+      "Success: Confirmed Product.Item does not already exist. Proceed to upload product.",
+    ],
   };
 }
 

--- a/src/scripts/import-needs-assessment-data/add-items.ts
+++ b/src/scripts/import-needs-assessment-data/add-items.ts
@@ -319,7 +319,7 @@ async function getProduct({
     data,
     orig,
     status,
-    logs: [...logs, "Success: Confirmed Product.Item does not exist."],
+    logs: [...logs, "Success: Confirmed Product.Item does not already exist. Proceed to upload product."],
   };
 }
 

--- a/src/scripts/import-needs-assessment-data/add-items.ts
+++ b/src/scripts/import-needs-assessment-data/add-items.ts
@@ -4,8 +4,83 @@ import {
   NeedAssessment,
   UploadWorkflowStatus,
   ProductUploadWorkflow,
-  // ProductUploadWorkflowResults,
+  ProductUploadWorkflowResults,
 } from "./types.d";
+
+/*  Add Products from Needs Assessment Data
+ * ------------------------------------------------------- */
+export async function addProducts(
+  data: NeedAssessment[],
+): Promise<Product[]> {
+  console.log("Adding Product.Items from the Needs Assessment data ...");
+
+  const uniqueProducts = consolidateProductsByCategory(data);
+
+  const results = await Promise.allSettled<ProductUploadWorkflow>(
+    uniqueProducts.map((product) => {
+      const initialWorkflow = {
+        data: {
+          product,
+        },
+        orig: product,
+        status: UploadWorkflowStatus.PROCESSING,
+        logs: [],
+      };
+
+      return Promise.resolve(initialWorkflow)
+        .then(parseProducts)
+        // .then(getCategory)
+        // .then(uploadCategory);
+    }),
+  );
+
+  // { "SUCCESS": [], "ALREADY_EXITS": [], ...}
+  const resultsMap: ProductUploadWorkflowResults = Object.fromEntries(
+    Object.keys(UploadWorkflowStatus).map((key) => [key, []]),
+  ) as ProductUploadWorkflowResults;
+
+  results.forEach((result) => {
+    const workflowResult = isFulfilled(result) ? result.value : result.reason;
+    const statusKey = workflowResult.status || UploadWorkflowStatus.OTHER;
+    resultsMap[statusKey].push(workflowResult);
+  });
+
+  console.log("Add Product.Items results:");
+  Object.keys(resultsMap).forEach((key) => {
+    console.log(`     ${key}: ${resultsMap[key].length}`);
+
+    // NOTE: uncomment & set the status key to debug different types of results
+    // if (key !== UploadWorkflowStatus.SUCCESS && key !== UploadWorkflowStatus.ALREADY_EXISTS) {
+    //   resultsMap[key].forEach((result) => {
+    //     console.log(result)
+    //     console.log("\n")
+    //   })
+    // }
+  });
+
+  console.log("Adding items completed!");
+
+  const validProducts: Product[] = [
+    ...resultsMap[UploadWorkflowStatus.SUCCESS],
+    ...resultsMap[UploadWorkflowStatus.ALREADY_EXISTS],
+  ].reduce((products: Product[], workflow: ProductUploadWorkflow) => {
+    return [...products, workflow.data];
+  }, [] as Product[]);
+
+  return validProducts;
+}
+
+const isFulfilled = <T>(
+  value: PromiseSettledResult<T>,
+): value is PromiseFulfilledResult<T> => {
+  return value.status === "fulfilled";
+};
+
+const _isRejected = <T>(
+  value: PromiseSettledResult<T>,
+): value is PromiseRejectedResult => {
+  return value.status === "rejected";
+};
 
 /*  Consolidate Products in each Category
  * ------------------------------------------------------- */
@@ -42,48 +117,49 @@ export function consolidateProductsByCategory(
 
 /*  Parse Products
  * ------------------------------------------------------- */
-export function parseProducts(
-  data: Product[],
+export function parseProducts({
+  data, 
   orig,
-  _status,
-): ProductUploadWorkflow {
-  const logs = [];
-  logs.push(`Parsing products ...`);
+  status,
+  logs,
+}: ProductUploadWorkflow): ProductUploadWorkflow {
+  logs = [...logs, `Log: parsing products...`];
+  // console.log("👉🏻 This is the data coming into the parse function:", data);
 
   const parsedData: Product[] = [];
-  const problematicItems: Product[] = [];
 
-  if (Array.isArray(data)) {
-    data.forEach((item: Product) => {
-      logs.push(`Parsing product: ${item.item}`);
+  if (typeof data === 'object' && data !== null) {
+    // Check if data contains a 'product' property
+    if ('product' in data) {
+      const product = (data.product as Product);
 
-      if (!item.category || !item.item || !item.unit) {
-        problematicItems.push(item);
+      logs.push(`Parsing product: ${product.item}`);
+
+      if (!product.category || !product.item || !product.unit) {
+        throw {
+          data,
+          orig,
+          status: UploadWorkflowStatus.ORIGINAL_DATA_INVALID,
+          logs: [
+            ...logs,
+            `Error: Invalid product input: "${product.item}-${product.ageGender}". Expected a non-null value for unit`,
+          ],
+        };
       } else {
         const processedProduct: Product = {
-          ...item,
+          ...product,
         };
         parsedData.push(processedProduct);
       }
-    });
-  } else {
-    console.log("Data property is not an array");
+    } else {
+    console.log("unexpected object structure:", JSON.stringify(data));
+    }
   }
-
-  const hasProblematicItems = problematicItems.length > 0;
-  const updatedStatus = hasProblematicItems
-    ? UploadWorkflowStatus.PROCESSING
-    : UploadWorkflowStatus.SUCCESS;
-
-  logs.push(
-    `Workflow completed. Status: ${problematicItems.length} product items were problematic: ${JSON.stringify(problematicItems, null, 2).replace(/\\n|"/g, "")}`,
-  );
-  // console.log(problematicItems)
 
   return {
     data: parsedData,
     orig,
-    status: updatedStatus,
+    status,
     logs,
   };
 }

--- a/src/scripts/import-needs-assessment-data/add-items.ts
+++ b/src/scripts/import-needs-assessment-data/add-items.ts
@@ -137,12 +137,12 @@ async function parseProducts({
 }: ProductUploadWorkflow): Promise<ProductUploadWorkflow> {
   logs = [...logs, `Log: parsing products...`];
 
-  const products =(() => {
+  const products = (() => {
     if (typeof data === "object" && data !== null) {
       if (Array.isArray(data)) {
         return data;
-      } else if (Object.hasOwn(data,'product')) {
-        return [((data as Record<string, unknown>).product as Product)];
+      } else if (Object.hasOwn(data, "product")) {
+        return [(data as Record<string, unknown>).product as Product];
       }
     }
     console.log("Unexpected object structure:", JSON.stringify(data));
@@ -152,27 +152,26 @@ async function parseProducts({
   return new Promise<ProductUploadWorkflow>((resolve, _reject) => {
     const parsedData: Product[] = [];
 
-      products.forEach(product => {
-        logs.push(`Parsing product: ${product.item}`);
-        
-          if (!product.category || !product.item || !product.unit) {
-            throw {
-              data,
-              orig,
-              status: UploadWorkflowStatus.ORIGINAL_DATA_INVALID,
-              logs: [
-                ...logs,
-                `Error: Invalid product input: "${product.item}-${product.ageGender}". Expected a non-null value in category, item, and unit.`,
-              ],
-            };
-          }
+    products.forEach((product) => {
+      logs.push(`Parsing product: ${product.item}`);
 
-          const processedProduct: Product = {
-            ...product,
-          };
-          parsedData.push(processedProduct);
-        
-      });
+      if (!product.category || !product.item || !product.unit) {
+        throw {
+          data,
+          orig,
+          status: UploadWorkflowStatus.ORIGINAL_DATA_INVALID,
+          logs: [
+            ...logs,
+            `Error: Invalid product input: "${product.item}-${product.ageGender}". Expected a non-null value in category, item, and unit.`,
+          ],
+        };
+      }
+
+      const processedProduct: Product = {
+        ...product,
+      };
+      parsedData.push(processedProduct);
+    });
 
     resolve({
       data: parsedData,

--- a/src/scripts/import-needs-assessment-data/add-items.ts
+++ b/src/scripts/import-needs-assessment-data/add-items.ts
@@ -207,10 +207,6 @@ async function getCategoryIds({
     },
   });
 
-  if (!response.ok) {
-    throw new Error(`HTTP error! Status: ${response.status}`);
-  }
-
   const categoryResults = await response.json();
   const matchingCategory = categoryResults.data.find((category) => {
     const parsedItem = data[0];

--- a/src/scripts/import-needs-assessment-data/add-items.ts
+++ b/src/scripts/import-needs-assessment-data/add-items.ts
@@ -101,18 +101,23 @@ export function consolidateProductsByCategory(
     }
   });
 
-  // Remove duplicates before further processing
-  const uniqueProducts = consolidatedProducts.filter(
-    (product, index, self) =>
-      index ===
-      self.findIndex(
-        (p) =>
-          p.item === product.item &&
-          p.category === product.category &&
-          p.ageGender === product.ageGender &&
-          p.sizeStyle === product.sizeStyle,
-      ),
-  );
+  // Create a set for unique products
+  const uniqueProductSet = new Set<string>();
+  const uniqueProducts: Product[] = [];
+
+  consolidatedProducts.forEach(product => {
+    const productKey = JSON.stringify([
+      product.item,
+      product.category,
+      product.ageGender,
+      product.sizeStyle
+    ]);
+
+    if (!uniqueProductSet.has(productKey)) {
+      uniqueProductSet.add(productKey);
+      uniqueProducts.push(product);
+    }
+  });
 
   // Print category counts after processing the data
   const categoryCounts = {};

--- a/src/scripts/import-needs-assessment-data/add-items.ts
+++ b/src/scripts/import-needs-assessment-data/add-items.ts
@@ -1,8 +1,8 @@
 import { STRAPI_ENV } from "../strapi-env";
+import { UploadWorkflowStatus } from "../statusCodes";
 import {
   Product,
   NeedAssessment,
-  UploadWorkflowStatus,
   ProductUploadWorkflow,
   ProductUploadWorkflowResults,
 } from "./types.d";
@@ -26,9 +26,8 @@ export async function addProducts(data: NeedAssessment[]): Promise<Product[]> {
       };
 
       return Promise.resolve(initialWorkflow)
-      .then(parseProducts)
-      .then(getProduct)
-      // .then(uploadCategory);
+        .then(parseProducts)
+        .then(getProduct);
     }),
   );
 
@@ -170,10 +169,7 @@ async function getProduct({
   status,
   logs,
 }: ProductUploadWorkflow): Promise<ProductUploadWorkflow> {
-  logs = [
-    ...logs,
-    `Log: Checking if Product.Item already exists.`,
-  ];
+  logs = [...logs, `Log: Checking if Product.Item already exists.`];
 
   //Fetch the data from Strapi
   const response = await fetch(`${STRAPI_ENV.URL}/items`, {
@@ -190,16 +186,19 @@ async function getProduct({
   // console.log("Strapi response status:", response.status);
   // console.log(body);
 
-  const matchingProduct = body.data.find(
-    (item) => {
-      const parsedItem = data[0];
-      return (
-        item.name.toLowerCase() === parsedItem.item.toLowerCase() &&
-        (parsedItem.ageGender === '' || item.age_gender === null || item.age_gender === '') &&
-        (parsedItem.sizeStyle === '' || item.size_style === '' || item.size_style === '') &&
-        (parsedItem.unit === '' || item.unit === null || item.unit === '')
-      );
-    });
+  const matchingProduct = body.data.find((item) => {
+    const parsedItem = data[0];
+    return (
+      item.name.toLowerCase() === parsedItem.item.toLowerCase() &&
+      (parsedItem.ageGender === "" ||
+        item.age_gender === null ||
+        item.age_gender === "") &&
+      (parsedItem.sizeStyle === "" ||
+        item.size_style === "" ||
+        item.size_style === "") &&
+      (parsedItem.unit === "" || item.unit === null || item.unit === "")
+    );
+  });
 
   if (!response.ok) {
     console.log("Non-ok response");

--- a/src/scripts/import-needs-assessment-data/index.ts
+++ b/src/scripts/import-needs-assessment-data/index.ts
@@ -6,7 +6,7 @@ import { addRegions } from "./add-regions";
 import { addSubregions } from "./add-subregions";
 import { addSurveys } from "./add-surveys";
 import { addCategories } from "./add-categories";
-import { consolidateProductsByCategory, parseProducts } from "./add-items";
+import { addProducts } from "./add-items";
 
 async function main() {
   try {
@@ -36,16 +36,8 @@ async function main() {
     const totalCountInNeeds = countObjectsInArray(data);
     console.log(`Total objects in needs array: ${totalCountInNeeds}`);
 
-    // Check individual functions are working
-    const processedProducts = consolidateProductsByCategory(data);
-    // console.log("Processed Products", processedProducts);
+    const _products = await addProducts(data);
 
-    try {
-      const result = parseProducts(processedProducts);
-      console.log("Result", result);
-    } catch (error) {
-      console.log("Error:", error.message);
-    }
   } catch (error) {
     console.error("Error processing needs assessment data", error);
     if (error.code === "ENOENT") {

--- a/src/scripts/import-needs-assessment-data/index.ts
+++ b/src/scripts/import-needs-assessment-data/index.ts
@@ -24,7 +24,7 @@ async function main() {
     const _categories = await addCategories(data);
 
     // Check the number of objects in the needs array to manually compare totals
-    function countObjectsInArray(data: any): number {
+    function countObjectsInArray(data): number {
       if (Array.isArray(data.needs)) {
         return data.needs.length;
       } else if (typeof data === "object" && data !== null) {

--- a/src/scripts/import-needs-assessment-data/index.ts
+++ b/src/scripts/import-needs-assessment-data/index.ts
@@ -5,7 +5,8 @@ import { readFileSync } from "fs";
 import { addRegions } from "./add-regions";
 import { addSubregions } from "./add-subregions";
 import { addSurveys } from "./add-surveys";
-import { consolidateCategories, getCategory } from "./add-categories";
+import { consolidateCategories, getCategory, uploadCategory } from "./add-categories";
+import { UploadWorkflowStatus } from "../statusCodes";
 
 async function main() {
   try {
@@ -31,7 +32,16 @@ async function main() {
           logs: ["Initial log"]
         });
         console.log(`Result for category ${categoryName}:`, categoryResult);
-      }catch (error) {
+
+        if (categoryResult.status !== UploadWorkflowStatus.ALREADY_EXISTS) {
+          try {
+            const uploadedCategory = await uploadCategory(categoryResult);
+            console.log(`Uploaded category ${categoryResult.orig}:`, uploadedCategory);
+          } catch (error) {
+            console.log(`Error uploading category ${categoryResult.orig}`, error);
+          }
+        }
+      } catch (error) {
         console.log(`Error processing category ${categoryName}`, error);
       }
     }

--- a/src/scripts/import-needs-assessment-data/index.ts
+++ b/src/scripts/import-needs-assessment-data/index.ts
@@ -18,7 +18,6 @@ async function main() {
     const _subregions = await addSubregions(data);
     const _surveys = await addSurveys(data);
     const _categories = await addCategories(data);
-
   } catch (error) {
     console.error("Error processing categories", error);
     if (error.code === "ENOENT") {

--- a/src/scripts/import-needs-assessment-data/index.ts
+++ b/src/scripts/import-needs-assessment-data/index.ts
@@ -37,7 +37,6 @@ async function main() {
     console.log(`Total objects in needs array: ${totalCountInNeeds}`);
 
     const _products = await addProducts(data);
-
   } catch (error) {
     console.error("Error processing needs assessment data", error);
     if (error.code === "ENOENT") {

--- a/src/scripts/import-needs-assessment-data/index.ts
+++ b/src/scripts/import-needs-assessment-data/index.ts
@@ -6,12 +6,15 @@ import { addRegions } from "./add-regions";
 import { addSubregions } from "./add-subregions";
 import { addSurveys } from "./add-surveys";
 import { addCategories } from "./add-categories";
-import { consolidateProductsByCategory } from "./add-items";
+import { consolidateProductsByCategory, parseProducts } from "./add-items";
 
 async function main() {
   try {
     //  Load the json data
-    const jsonData = readFileSync(join(__dirname, "./needs-data(1).json"), "utf8");
+    const jsonData = readFileSync(
+      join(__dirname, "./needs-data(1).json"),
+      "utf8",
+    );
     const data = JSON.parse(jsonData);
 
     //  Process the data and upload to Strapi collections
@@ -24,10 +27,10 @@ async function main() {
     function countObjectsInArray(data: any): number {
       if (Array.isArray(data.needs)) {
         return data.needs.length;
-      } else if (typeof data === 'object' && data !== null) {
+      } else if (typeof data === "object" && data !== null) {
         return Object.keys(data).length;
       } else {
-        throw new Error('Invalid input: expected an array or object');
+        throw new Error("Invalid input: expected an array or object");
       }
     }
     const totalCountInNeeds = countObjectsInArray(data);
@@ -35,10 +38,16 @@ async function main() {
 
     // Check individual functions are working
     const processedProducts = consolidateProductsByCategory(data);
-    console.log('Processed Products', processedProducts);
+    // console.log("Processed Products", processedProducts);
 
+    try {
+      const result = parseProducts(processedProducts);
+      console.log('Result', result);
+    } catch (error) {
+      console.log('Error:', error.message);
+    }
   } catch (error) {
-    console.error("Error processing products", error);
+    console.error("Error processing needs assessment data", error);
     if (error.code === "ENOENT") {
       console.error(`File not found: ${error.path}`);
     } else if (error instanceof TypeError) {

--- a/src/scripts/import-needs-assessment-data/index.ts
+++ b/src/scripts/import-needs-assessment-data/index.ts
@@ -11,10 +11,7 @@ import { addProducts } from "./add-items";
 async function main() {
   try {
     //  Load the json data
-    const jsonData = readFileSync(
-      join(__dirname, "./needs-data.json"),
-      "utf8",
-    );
+    const jsonData = readFileSync(join(__dirname, "./needs-data.json"), "utf8");
     const data = JSON.parse(jsonData);
 
     //  Process the data and upload to Strapi collections

--- a/src/scripts/import-needs-assessment-data/index.ts
+++ b/src/scripts/import-needs-assessment-data/index.ts
@@ -42,9 +42,9 @@ async function main() {
 
     try {
       const result = parseProducts(processedProducts);
-      console.log('Result', result);
+      console.log("Result", result);
     } catch (error) {
-      console.log('Error:', error.message);
+      console.log("Error:", error.message);
     }
   } catch (error) {
     console.error("Error processing needs assessment data", error);

--- a/src/scripts/import-needs-assessment-data/index.ts
+++ b/src/scripts/import-needs-assessment-data/index.ts
@@ -5,8 +5,7 @@ import { readFileSync } from "fs";
 import { addRegions } from "./add-regions";
 import { addSubregions } from "./add-subregions";
 import { addSurveys } from "./add-surveys";
-import { consolidateCategories, getCategory, uploadCategory } from "./add-categories";
-import { UploadWorkflowStatus } from "../statusCodes";
+import { addCategories } from "./add-categories";
 
 async function main() {
   try {
@@ -18,33 +17,7 @@ async function main() {
     const _regions = await addRegions(data);
     const _subregions = await addSubregions(data);
     const _surveys = await addSurveys(data);
-
-    // Check individual functions are working
-    const processedCategories = consolidateCategories(data);
-    console.log('Processed Categories', processedCategories);
-
-    for (const categoryName of processedCategories) {
-      try {
-        const categoryResult = await getCategory({
-          data: {category: categoryName},
-          orig: categoryName,
-          status: 'PROCESSING',
-          logs: ["Initial log"]
-        });
-        console.log(`Result for category ${categoryName}:`, categoryResult);
-
-        if (categoryResult.status !== UploadWorkflowStatus.ALREADY_EXISTS) {
-          try {
-            const uploadedCategory = await uploadCategory(categoryResult);
-            console.log(`Uploaded category ${categoryResult.orig}:`, uploadedCategory);
-          } catch (error) {
-            console.log(`Error uploading category ${categoryResult.orig}`, error);
-          }
-        }
-      } catch (error) {
-        console.log(`Error processing category ${categoryName}`, error);
-      }
-    }
+    const _categories = await addCategories(data);
 
   } catch (error) {
     console.error("Error processing categories", error);

--- a/src/scripts/import-needs-assessment-data/index.ts
+++ b/src/scripts/import-needs-assessment-data/index.ts
@@ -5,6 +5,7 @@ import { readFileSync } from "fs";
 import { addRegions } from "./add-regions";
 import { addSubregions } from "./add-subregions";
 import { addSurveys } from "./add-surveys";
+import { consolidateCategories, getCategory } from "./add-categories";
 
 async function main() {
   try {
@@ -16,8 +17,27 @@ async function main() {
     const _regions = await addRegions(data);
     const _subregions = await addSubregions(data);
     const _surveys = await addSurveys(data);
+
+    // Check individual functions are working
+    const processedCategories = consolidateCategories(data);
+    console.log('Processed Categories', processedCategories);
+
+    for (const categoryName of processedCategories) {
+      try {
+        const categoryResult = await getCategory({
+          data: {category: categoryName},
+          orig: categoryName,
+          status: 'PROCESSING',
+          logs: ["Initial log"]
+        });
+        console.log(`Result for category ${categoryName}:`, categoryResult);
+      }catch (error) {
+        console.log(`Error processing category ${categoryName}`, error);
+      }
+    }
+
   } catch (error) {
-    console.error("Error processing needs assessment data", error);
+    console.error("Error processing categories", error);
     if (error.code === "ENOENT") {
       console.error(`File not found: ${error.path}`);
     } else if (error instanceof TypeError) {

--- a/src/scripts/import-needs-assessment-data/index.ts
+++ b/src/scripts/import-needs-assessment-data/index.ts
@@ -6,11 +6,12 @@ import { addRegions } from "./add-regions";
 import { addSubregions } from "./add-subregions";
 import { addSurveys } from "./add-surveys";
 import { addCategories } from "./add-categories";
+import { consolidateProductsByCategory } from "./add-items";
 
 async function main() {
   try {
     //  Load the json data
-    const jsonData = readFileSync(join(__dirname, "./needs-data.json"), "utf8");
+    const jsonData = readFileSync(join(__dirname, "./needs-data(1).json"), "utf8");
     const data = JSON.parse(jsonData);
 
     //  Process the data and upload to Strapi collections
@@ -18,8 +19,26 @@ async function main() {
     const _subregions = await addSubregions(data);
     const _surveys = await addSurveys(data);
     const _categories = await addCategories(data);
+
+    // Check the number of objects in the needs array to manually compare totals
+    function countObjectsInArray(data: any): number {
+      if (Array.isArray(data.needs)) {
+        return data.needs.length;
+      } else if (typeof data === 'object' && data !== null) {
+        return Object.keys(data).length;
+      } else {
+        throw new Error('Invalid input: expected an array or object');
+      }
+    }
+    const totalCountInNeeds = countObjectsInArray(data);
+    console.log(`Total objects in needs array: ${totalCountInNeeds}`);
+
+    // Check individual functions are working
+    const processedProducts = consolidateProductsByCategory(data);
+    console.log('Processed Products', processedProducts);
+
   } catch (error) {
-    console.error("Error processing categories", error);
+    console.error("Error processing products", error);
     if (error.code === "ENOENT") {
       console.error(`File not found: ${error.path}`);
     } else if (error instanceof TypeError) {

--- a/src/scripts/import-needs-assessment-data/index.ts
+++ b/src/scripts/import-needs-assessment-data/index.ts
@@ -12,7 +12,7 @@ async function main() {
   try {
     //  Load the json data
     const jsonData = readFileSync(
-      join(__dirname, "./needs-data(1).json"),
+      join(__dirname, "./needs-data.json"),
       "utf8",
     );
     const data = JSON.parse(jsonData);

--- a/src/scripts/import-needs-assessment-data/types.d.ts
+++ b/src/scripts/import-needs-assessment-data/types.d.ts
@@ -23,6 +23,8 @@ export type Survey = {
   year: string;
   quarter: string;
 };
+export type CategoryUploadWorkflow = UploadWorkflow<Category>;
+export type CategoryUploadWorkflowResults = UploadWorkflowResults<Category>;
 
 export type Region = {
   region: string;
@@ -31,6 +33,10 @@ export type Region = {
 export type Subregion = {
   subregion: string;
 };
+
+export type Category = {
+  category: string;
+}
 
 export type NeedAssessment = {
   id: string;

--- a/src/scripts/import-needs-assessment-data/types.d.ts
+++ b/src/scripts/import-needs-assessment-data/types.d.ts
@@ -38,6 +38,14 @@ export type Category = {
   category: string;
 }
 
+export type Product = {
+  category: string;
+  item: string;
+  ageGender?: string;
+  sizeStyle?: string;
+  unit?: string;
+}
+
 export type NeedAssessment = {
   id: string;
   survey: {

--- a/src/scripts/import-needs-assessment-data/types.d.ts
+++ b/src/scripts/import-needs-assessment-data/types.d.ts
@@ -46,6 +46,7 @@ export type Product = {
   ageGender?: string;
   sizeStyle?: string;
   unit?: string;
+  categoryId?: number;
 };
 
 export type NeedAssessment = {

--- a/src/scripts/import-needs-assessment-data/types.d.ts
+++ b/src/scripts/import-needs-assessment-data/types.d.ts
@@ -36,7 +36,7 @@ export type Subregion = {
 
 export type Category = {
   category: string;
-}
+};
 
 export type Product = {
   category: string;
@@ -44,7 +44,7 @@ export type Product = {
   ageGender?: string;
   sizeStyle?: string;
   unit?: string;
-}
+};
 
 export type NeedAssessment = {
   id: string;

--- a/src/scripts/import-needs-assessment-data/types.d.ts
+++ b/src/scripts/import-needs-assessment-data/types.d.ts
@@ -1,32 +1,10 @@
 import { UploadWorkflowStatus } from "../statusCodes";
 
-export type UploadWorkflow<T> = {
-  data: T;
-  orig: string | T; // Union type allowing either a csv string or parsed JSON object
-  status: UploadWorkflowStatus;
-  logs: string[];
-};
-
-export type UploadWorkflowResults<T> = {
-  [Property in keyof UploadWorkflowStatus]: T[];
-};
-
-export type RegionUploadWorkflow = UploadWorkflow<Region>;
-export type RegionUploadWorkflowResults = UploadWorkflowResults<Region>;
-export type SubregionUploadWorkflow = UploadWorkflow<Subregion>;
-export type SubregionUploadWorkflowResults = UploadWorkflowResults<Subregion>;
-export type SurveyUploadWorkflow = UploadWorkflow<Survey>;
-export type SurveyUploadWorkflowResults = UploadWorkflowResults<Survey>;
-
 export type Survey = {
   reference: string;
   year: string;
   quarter: string;
 };
-export type CategoryUploadWorkflow = UploadWorkflow<Category>;
-export type CategoryUploadWorkflowResults = UploadWorkflowResults<Category>;
-export type ProductUploadWorkflow = UploadWorkflow<Product[]>;
-export type ProductUploadWorkflowResults = UploadWorkflowResults<Product[]>;
 
 export type Region = {
   region: string;
@@ -71,3 +49,29 @@ export type NeedAssessment = {
   };
   need: number;
 };
+
+export type UploadWorkflow<T> = {
+  data: T;
+  orig: string | T; // Union type allowing either a csv string or parsed JSON object
+  status: UploadWorkflowStatus;
+  logs: string[];
+};
+
+export type UploadWorkflowResults<T> = {
+  [Property in keyof UploadWorkflowStatus]: T[];
+};
+
+export type RegionUploadWorkflow = UploadWorkflow<Region>;
+export type RegionUploadWorkflowResults = UploadWorkflowResults<Region>;
+
+export type SubregionUploadWorkflow = UploadWorkflow<Subregion>;
+export type SubregionUploadWorkflowResults = UploadWorkflowResults<Subregion>;
+
+export type SurveyUploadWorkflow = UploadWorkflow<Survey>;
+export type SurveyUploadWorkflowResults = UploadWorkflowResults<Survey>;
+
+export type CategoryUploadWorkflow = UploadWorkflow<Category>;
+export type CategoryUploadWorkflowResults = UploadWorkflowResults<Category>;
+
+export type ProductUploadWorkflow = UploadWorkflow<Product[]>;
+export type ProductUploadWorkflowResults = UploadWorkflowResults<Product[]>;

--- a/src/scripts/import-needs-assessment-data/types.d.ts
+++ b/src/scripts/import-needs-assessment-data/types.d.ts
@@ -25,6 +25,8 @@ export type Survey = {
 };
 export type CategoryUploadWorkflow = UploadWorkflow<Category>;
 export type CategoryUploadWorkflowResults = UploadWorkflowResults<Category>;
+export type ProductUploadWorkflow = UploadWorkflow<Product[]>;
+export type ProductUploadWorkflowResults = UploadWorkflowResults<Product[]>;
 
 export type Region = {
   region: string;

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -771,6 +771,7 @@ export interface ApiProductCategory extends Struct.CollectionTypeSchema {
 export interface ApiProductItem extends Struct.CollectionTypeSchema {
   collectionName: "items";
   info: {
+    description: "";
     displayName: "Product.Item";
     pluralName: "items";
     singularName: "item";
@@ -801,6 +802,7 @@ export interface ApiProductItem extends Struct.CollectionTypeSchema {
     publishedAt: Schema.Attribute.DateTime;
     secondHand: Schema.Attribute.Component<"product.second-hand", false>;
     size_style: Schema.Attribute.String;
+    unit: Schema.Attribute.String;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
       Schema.Attribute.Private;


### PR DESCRIPTION
## What changed?

This pull request currently populates the `name` field type for the `Product.Category` collection. It relates to task 1 in PR #112. This collection still requires the `items` relation field type to be populated.

Still to do in this PR:

- [x] - Add a `unit` field type to the Strapi `Product.Item` collection.
- [x] - Populate the Strapi `Product.Item` collection, using the needs data to create items with the following fields - `name`, `age_gender`, `size_style`, `category`, `unit`.

**_**Update:_** This pull request now populates the `Product.Category` and `Product.Item` collections.

## How can you test this?
Add the attached [needs-data.json](https://github.com/user-attachments/files/17951499/needs-data.json) file to the `src/scripts/import-needs-assessment-data` folder, setup the `src/scripts/.env` file, then run the dev server in one terminal and `yarn script:import-needs-assessment-data` in another. The logs should show you that 11 categories and 290 products have been created successfully or already exist. (The json file was updated with the full dataset Nov. 28/24)

To test a small amount of data when working with the add-items scripts for the `Product.Item` collection, **use the following demo-data** [needs-data(1).json](https://github.com/user-attachments/files/18495315/needs-data.1.json) instead of the above-noted json file. 
The logs should show you the following breakdown: 
5 categories processed (either in SUCCESS or ALREADY_EXISTS) and 
26 products processed (2 ORIGINAL_DATA_INVALID and 24 in SUCCESS or ALREADY_EXISTS).


