### PR TITLE
Pr 210 review

### DIFF
--- a/src/scripts/import-needs-assessment-data/add-categories.ts
+++ b/src/scripts/import-needs-assessment-data/add-categories.ts
@@ -19,25 +19,25 @@ export async function addCategories(
 
   const results = await Promise.allSettled<CategoryUploadWorkflow>(
     uniqueCategories.map((category) => {
-        const initialWorkflow = {
-          data: {
-            category,
-          },
-          orig: category,
-          status: UploadWorkflowStatus.PROCESSING,
-          logs: [],
-        };
+      const initialWorkflow = {
+        data: {
+          category,
+        },
+        orig: category,
+        status: UploadWorkflowStatus.PROCESSING,
+        logs: [],
+      };
 
-        return Promise.resolve(initialWorkflow)
-          .then(parseCategory)
-          .then(getCategory)
-          .then(uploadCategory);
-    })
+      return Promise.resolve(initialWorkflow)
+        .then(parseCategory)
+        .then(getCategory)
+        .then(uploadCategory);
+    }),
   );
 
   // { "SUCCESS": [], "ALREADY_EXITS": [], ...}
   const resultsMap: CategoryUploadWorkflowResults = Object.fromEntries(
-    Object.keys(UploadWorkflowStatus).map((key) => [key, []])
+    Object.keys(UploadWorkflowStatus).map((key) => [key, []]),
   ) as CategoryUploadWorkflowResults;
 
   results.forEach((result) => {
@@ -159,7 +159,7 @@ async function getCategory({
 
   // log strapi response status
   //console.log("Strapi response status:", response.status);
-  
+
   const matchingCategory = body.data.find(
     (category) => category.name.toLowerCase() === data.category.toLowerCase(),
   );

--- a/src/scripts/import-needs-assessment-data/add-items.ts
+++ b/src/scripts/import-needs-assessment-data/add-items.ts
@@ -42,38 +42,43 @@ export function consolidateProductsByCategory(
 
 /*  Parse Products
  * ------------------------------------------------------- */
-export function parseProducts(data: Product[], orig, status): ProductUploadWorkflow {
+export function parseProducts(
+  data: Product[],
+  orig,
+  status,
+): ProductUploadWorkflow {
   const logs = [];
   logs.push(`Parsing products ...`);
-  
+
   const parsedData: Product[] = [];
   const problematicItems: Product[] = [];
 
   if (Array.isArray(data)) {
-  data.forEach((item: Product) => {
-    logs.push(`Parsing product: ${item.item}`);
+    data.forEach((item: Product) => {
+      logs.push(`Parsing product: ${item.item}`);
 
-    if (!item.category || !item.item || !item.unit) {
-      problematicItems.push(item);
-    } else {
-      const processedProduct: Product = {
-        ...item,
-        parsed: true
-      };
-      parsedData.push(processedProduct);
-    }
-
-  });
+      if (!item.category || !item.item || !item.unit) {
+        problematicItems.push(item);
+      } else {
+        const processedProduct: Product = {
+          ...item,
+          parsed: true,
+        };
+        parsedData.push(processedProduct);
+      }
+    });
   } else {
     console.log("Data property is not an array");
   }
 
   const hasProblematicItems = problematicItems.length > 0;
   const updatedStatus = hasProblematicItems
-  ? UploadWorkflowStatus.ORIGINAL_DATA_INVALID
-  : UploadWorkflowStatus.SUCCESS
+    ? UploadWorkflowStatus.ORIGINAL_DATA_INVALID
+    : UploadWorkflowStatus.SUCCESS;
 
-  logs.push(`Workflow completed. Status: ${problematicItems.length} product items were problematic: ${JSON.stringify(problematicItems, null, 2).replace(/\\n|"/g, '')}`);
+  logs.push(
+    `Workflow completed. Status: ${problematicItems.length} product items were problematic: ${JSON.stringify(problematicItems, null, 2).replace(/\\n|"/g, "")}`,
+  );
   // console.log(problematicItems)
 
   return {

--- a/src/scripts/import-needs-assessment-data/index.ts
+++ b/src/scripts/import-needs-assessment-data/index.ts
@@ -40,9 +40,9 @@ async function main() {
 
     try {
       const result = parseProducts(processedProducts);
-      console.log('Result', result);
+      console.log("Result", result);
     } catch (error) {
-      console.log('Error:', error.message);
+      console.log("Error:", error.message);
     }
   } catch (error) {
     console.error("Error processing needs assessment data", error);


### PR DESCRIPTION
## What changed?
- Responding to guel-codes comments on this pull request.
- Simplified logic in chaining .then() function calls.
- Simplified logic for populating resultsMap. 
- Ran auto format checker.

<!-- include a link to a GitHub issue, if applicable -->
[Link to Pull Request and review](https://github.com/distributeaid/aggregated-public-information/pull/210)

## How can you test this?
Add the attached [needs-data.json](https://github.com/user-attachments/files/17951499/needs-data.json) file to the src/scripts/import-needs-assessment-data folder, setup the src/scripts/.env file. Rename needs-data.json to needs-data.json(1) or change target filename in src/scripts/import-needs-assessment-data/index.ts.

Create dummy API key for local Strapi instance and use for STRAPI_API_KEY= in .env.

Comment out existing console.log() calls in index.ts. Uncomment and isolate addCategories function and _categories.

Then run the dev server in one terminal and yarn script:import-needs-assessment-data in another. The logs should show you that 11 categories have been created successfully or already exist. (The json file was updated with the full dataset Nov. 28/24).

## Result of local test populating Product.Category:
![strapi](https://github.com/user-attachments/assets/9eb64214-d7d2-4ffa-8075-69766a53c65d)
