### PR TITLE
fix rm behavior in `yarn build`

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "name": "A Strapi developer"
   },
   "scripts": {
-    "build": "rm -r ./dist && strapi build",
+    "build": "rm -rf ./dist && strapi build",
     "develop": "strapi develop",
     "start": "strapi start",
     "strapi": "strapi",


### PR DESCRIPTION
This fixes #289