### PR TITLE
feat(data-ingestion): Add function to consolidate historic needs data

### DIFF
--- a/src/scripts/import-needs-assessment-data/add-needs.ts
+++ b/src/scripts/import-needs-assessment-data/add-needs.ts
@@ -4,114 +4,108 @@
 import {
   Need,
   NeedAssessment,
-//   NeedUploadWorkflow,
-//   NeedUploadWorkflowResults,
+  //   NeedUploadWorkflow,
+  //   NeedUploadWorkflowResults,
 } from "./types.d";
 
 // Note: Uncomment the required imports during implementation in the code.
 
 /* Consolidate the Needs and remove duplicates
-* --------------------------------------------- */
-export function consolidateNeedsByRegion(
-    data: NeedAssessment[],
-): Need[] {
-    const consolidatedNeeds: Need[] = [];
+ * --------------------------------------------- */
+export function consolidateNeedsByRegion(data: NeedAssessment[]): Need[] {
+  const consolidatedNeeds: Need[] = [];
 
-    data.forEach((assessment) => {
-        const need = assessment;
+  data.forEach((assessment) => {
+    const need = assessment;
 
-        if (need.product) {
-            consolidatedNeeds.push({
-                product: {
-                    category: need.product.category,
-                    item: need.product.item,
-                    ageGender: need.product.ageGender || "",
-                    sizeStyle: need.product.sizeStyle || "",
-                    unit: need.product.unit || ""
-                },
-                amount: need.need,
-                survey: {
-                    reference: need.survey.id,
-                    year: need.survey.year,
-                    quarter: need.survey.quarter
-                },
-                region: need.place.region,
-                subregion: need.place.subregion || "",
-            });
-        }
-    });
+    if (need.product) {
+      consolidatedNeeds.push({
+        product: {
+          category: need.product.category,
+          item: need.product.item,
+          ageGender: need.product.ageGender || "",
+          sizeStyle: need.product.sizeStyle || "",
+          unit: need.product.unit || "",
+        },
+        amount: need.need,
+        survey: {
+          reference: need.survey.id,
+          year: need.survey.year,
+          quarter: need.survey.quarter,
+        },
+        region: need.place.region,
+        subregion: need.place.subregion || "",
+      });
+    }
+  });
 
-    const uniqueNeeds: Need[] = [];
-    const duplicateNeeds: Need[] =[];   
+  const uniqueNeeds: Need[] = [];
+  const duplicateNeeds: Need[] = [];
 
-    consolidatedNeeds.forEach((currentNeed) => {
-        const existingNeedIndex = uniqueNeeds.findIndex(need =>
-            areNeedsEqual(need, currentNeed)
-        );
+  consolidatedNeeds.forEach((currentNeed) => {
+    const existingNeedIndex = uniqueNeeds.findIndex((need) =>
+      areNeedsEqual(need, currentNeed),
+    );
 
-        if (existingNeedIndex !==-1) {
-            duplicateNeeds.push(currentNeed);
-        } else {
-            uniqueNeeds.push(currentNeed);
-        }
+    if (existingNeedIndex !== -1) {
+      duplicateNeeds.push(currentNeed);
+    } else {
+      uniqueNeeds.push(currentNeed);
+    }
+  });
 
-    });
+  // Gather region counts for analysis after processing the data
+  const regionCounts = {};
+  uniqueNeeds.forEach((need) => {
+    regionCounts[need.region] = (regionCounts[need.region] || 0) + 1;
+  });
 
-    // Gather region counts for analysis after processing the data
-    const regionCounts = {};
-    uniqueNeeds.forEach((need) => {
-        regionCounts[need.region] = 
-            (regionCounts[need.region] || 0) +1;
-    });
+  // Logs for investigating the data processed
+  console.log(`Total unique needs: ${uniqueNeeds.length}`);
+  console.log("Region counts:", regionCounts);
 
-    // Logs for investigating the data processed
-    console.log(`Total unique needs: ${uniqueNeeds.length}`);
-    console.log("Region counts:", regionCounts);
+  console.log(`Number of duplicates: ${duplicateNeeds.length}`);
 
-    console.log(`Number of duplicates: ${duplicateNeeds.length}`);
+  // NOTE: uncomment to view duplicates for data analysis
+  // if (duplicateNeeds.length > 0) {
+  //     console.log("\nDuplicate needs details:");
+  //     duplicateNeeds.forEach((need, index) => {
+  //     console.log(`\nDuplicate #${index + 1}:`);
+  //     console.log(`Region: ${need.region}`);
+  //     console.log(`Subregion: ${need.subregion}`);
+  //     console.log(`Product: ${JSON.stringify(need.product, null, 2)}`);
+  //     console.log(`Amount: ${need.amount}`);
+  //     console.log(`Survey: ${JSON.stringify(need.survey)}`);
+  // });
+  // }
 
-    // NOTE: uncomment to view duplicates for data analysis
-    // if (duplicateNeeds.length > 0) {
-    //     console.log("\nDuplicate needs details:");
-    //     duplicateNeeds.forEach((need, index) => {
-    //     console.log(`\nDuplicate #${index + 1}:`);
-    //     console.log(`Region: ${need.region}`);
-    //     console.log(`Subregion: ${need.subregion}`);
-    //     console.log(`Product: ${JSON.stringify(need.product, null, 2)}`);
-    //     console.log(`Amount: ${need.amount}`);
-    //     console.log(`Survey: ${JSON.stringify(need.survey)}`);
-    // });
-    // }
-
-    return uniqueNeeds;
+  return uniqueNeeds;
 }
 
 function areNeedsEqual(need1: Need, need2: Need): boolean {
-    if (!need1 || !need2) return false;
+  if (!need1 || !need2) return false;
 
-    const productsMatch = (
-        need1.product.item === need2.product.item &&
-        need1.product.category === need2.product.category &&
-        need1.product.ageGender === need2.product.ageGender &&
-        need1.product.sizeStyle === need2.product.sizeStyle &&
-        need1.product.unit === need2.product.unit
-    );
+  const productsMatch =
+    need1.product.item === need2.product.item &&
+    need1.product.category === need2.product.category &&
+    need1.product.ageGender === need2.product.ageGender &&
+    need1.product.sizeStyle === need2.product.sizeStyle &&
+    need1.product.unit === need2.product.unit;
 
-    if (!productsMatch) return false;
+  if (!productsMatch) return false;
 
-    if (need1.amount !== need2.amount) return false;
-   
-    const surveysMatch = (
-        need1.survey.reference === need2.survey.reference &&
-        need1.survey.year === need2.survey.year &&
-        need1.survey.quarter === need2.survey.quarter
-    );
-    
-    if (!surveysMatch) return false;
-    
-    if (need1.region !== need2.region) return false;
+  if (need1.amount !== need2.amount) return false;
 
-    if (need1.subregion !== need2.subregion) return false;
+  const surveysMatch =
+    need1.survey.reference === need2.survey.reference &&
+    need1.survey.year === need2.survey.year &&
+    need1.survey.quarter === need2.survey.quarter;
 
-    return true;
+  if (!surveysMatch) return false;
+
+  if (need1.region !== need2.region) return false;
+
+  if (need1.subregion !== need2.subregion) return false;
+
+  return true;
 }

--- a/src/scripts/import-needs-assessment-data/add-needs.ts
+++ b/src/scripts/import-needs-assessment-data/add-needs.ts
@@ -41,45 +41,8 @@ export function consolidateNeedsByRegion(
         }
     });
 
-    // Create a set for unique needs - doesn't work - has 10 duplicates
-    // const uniqueNeedSet = new Set<string>();
     const uniqueNeeds: Need[] = [];
     const duplicateNeeds: Need[] =[];
-
-    // consolidatedNeeds.forEach((need) => {
-    //     const needKey = JSON.stringify([
-    //         need.product.item,
-    //         need.product.category,
-    //         need.product.ageGender || "",
-    //         need.product.sizeStyle || "",
-    //         need.product.unit || "",
-    //         // product: {
-    //         //     category: need.product.category,
-    //         //     item: need.product.item,
-    //         //     ageGender: need.product.ageGender || "",
-    //         //     sizeStyle: need.product.sizeStyle || "",
-    //         //     unit: need.product.unit || ""
-    //         // },
-    //         need.amount,
-    //         need.survey.reference,
-    //         need.survey.year,
-    //         need.survey.quarter,
-    //         need.region,
-    //         need.subregion || ""
-    //     ]);
-
-        // console.log('needKey', needKey);
-
-        // if(!uniqueNeedSet.has(needKey)) {
-        //     uniqueNeedSet.add(needKey);
-        //     uniqueNeeds.push(need);
-        // } else {
-        //     console.log('Duplicate found with key:', needKey);
-        //     console.log('Duplicate need:', need);
-        //     duplicateNeeds.push(need);
-            
-        // }
-    // });
 
     consolidatedNeeds.forEach((currentNeed) => {
         let isDuplicate = false;
@@ -91,23 +54,21 @@ export function consolidateNeedsByRegion(
             }
         }
 
-        if (!isDuplicate) {
-            uniqueNeeds.push(currentNeed)
+        if (isDuplicate) {
+            duplicateNeeds.push(currentNeed)
         } else {
-            console.log('Duplicate found:');
-            console.log('Duplicate need:', currentNeed);
-            duplicateNeeds.push(currentNeed);
+            uniqueNeeds.push(currentNeed);
         }
     });    
-    
 
-    // Print region counts after processing the data
+    // Print region counts for analysis after processing the data
     const regionCounts = {};
     uniqueNeeds.forEach((need) => {
         regionCounts[need.region] = 
             (regionCounts[need.region] || 0) +1;
     });
 
+    // Logs for debugging issues with duplicates
     console.log(`Total unique needs: ${uniqueNeeds.length}`);
     console.log("Region counts:", regionCounts);
 
@@ -130,32 +91,27 @@ export function consolidateNeedsByRegion(
 function areNeedsEqual(need1: Need, need2: Need): boolean {
     if (!need1 || !need2) return false;
 
-    if (
-        need1.product.category !== need2.product.category ||
-        need1.product.item !== need2.product.item ||
-        need1.product.ageGender !== need2.product.ageGender ||
-        need1.product.sizeStyle !== need2.product.sizeStyle ||
-        need1.product.unit !== need2.product.unit
-    ) {
-        return false;
-    }
+    const productsMatch = (
+        need1.product.item === need2.product.item &&
+        need1.product.category === need2.product.category &&
+        need1.product.ageGender === need2.product.ageGender &&
+        need1.product.sizeStyle === need2.product.sizeStyle &&
+        need1.product.unit === need2.product.unit
+    );
+
+    if (!productsMatch) return false;
 
     if (need1.amount !== need2.amount) return false;
+   
+    const surveysMatch = (
+        need1.survey.reference === need2.survey.reference &&
+        need1.survey.year === need2.survey.year &&
+        need1.survey.quarter === need2.survey.quarter
+    );
+    
+    if (!surveysMatch) return false;
+    
+    if (need1.region !== need2.region) return false;
 
-    if (
-        need1.survey.reference !== need2.survey.reference ||
-        need1.survey.year !== need2.survey.year ||
-        need1.survey.quarter !== need2.survey.quarter
-    ) {
-        return false;
-    }
-
-    if (
-        need1.region !== need2.region ||
-        need1.subregion !== need2.subregion
-    ) {
-        return false;
-    }
-
-    return true;
+    if (need1.subregion !== need2.subregion) return false;
 }

--- a/src/scripts/import-needs-assessment-data/add-needs.ts
+++ b/src/scripts/import-needs-assessment-data/add-needs.ts
@@ -1,11 +1,161 @@
 // import qs from "qs";
 // import { STRAPI_ENV } from "../strapi-env";
-// import { UploadWorkflowStatus } from "../_utils/statusCodes";
-// import {
-//   Need,
-//   NeedAssessment,
+// import { UploadWorkflowStatus } from "../statusCodes";
+import {
+  Need,
+  NeedAssessment,
 //   NeedUploadWorkflow,
 //   NeedUploadWorkflowResults,
-// } from "./types.d";
+} from "./types.d";
 
 // Note: Uncomment the required imports during implementation in the code.
+
+/* Consolidate the Needs and remove duplicates
+* --------------------------------------------- */
+export function consolidateNeedsByRegion(
+    data: NeedAssessment[],
+): Need[] {
+    const consolidatedNeeds: Need[] = [];
+
+    data.forEach((assessment) => {
+        const need = assessment;
+
+        if (need.product) {
+            consolidatedNeeds.push({
+                product: {
+                    category: need.product.category,
+                    item: need.product.item,
+                    ageGender: need.product.ageGender || "",
+                    sizeStyle: need.product.sizeStyle || "",
+                    unit: need.product.unit || ""
+                },
+                amount: need.need,
+                survey: {
+                    reference: need.survey.id,
+                    year: need.survey.year,
+                    quarter: need.survey.quarter
+                },
+                region: need.place.region,
+                subregion: need.place.subregion || "",
+            });
+        }
+    });
+
+    // Create a set for unique needs - doesn't work - has 10 duplicates
+    // const uniqueNeedSet = new Set<string>();
+    const uniqueNeeds: Need[] = [];
+    const duplicateNeeds: Need[] =[];
+
+    // consolidatedNeeds.forEach((need) => {
+    //     const needKey = JSON.stringify([
+    //         need.product.item,
+    //         need.product.category,
+    //         need.product.ageGender || "",
+    //         need.product.sizeStyle || "",
+    //         need.product.unit || "",
+    //         // product: {
+    //         //     category: need.product.category,
+    //         //     item: need.product.item,
+    //         //     ageGender: need.product.ageGender || "",
+    //         //     sizeStyle: need.product.sizeStyle || "",
+    //         //     unit: need.product.unit || ""
+    //         // },
+    //         need.amount,
+    //         need.survey.reference,
+    //         need.survey.year,
+    //         need.survey.quarter,
+    //         need.region,
+    //         need.subregion || ""
+    //     ]);
+
+        // console.log('needKey', needKey);
+
+        // if(!uniqueNeedSet.has(needKey)) {
+        //     uniqueNeedSet.add(needKey);
+        //     uniqueNeeds.push(need);
+        // } else {
+        //     console.log('Duplicate found with key:', needKey);
+        //     console.log('Duplicate need:', need);
+        //     duplicateNeeds.push(need);
+            
+        // }
+    // });
+
+    consolidatedNeeds.forEach((currentNeed) => {
+        let isDuplicate = false;
+
+        for (const existingNeed of uniqueNeeds) {
+            if (areNeedsEqual(currentNeed, existingNeed)) {
+                isDuplicate = true;
+                break;
+            }
+        }
+
+        if (!isDuplicate) {
+            uniqueNeeds.push(currentNeed)
+        } else {
+            console.log('Duplicate found:');
+            console.log('Duplicate need:', currentNeed);
+            duplicateNeeds.push(currentNeed);
+        }
+    });    
+    
+
+    // Print region counts after processing the data
+    const regionCounts = {};
+    uniqueNeeds.forEach((need) => {
+        regionCounts[need.region] = 
+            (regionCounts[need.region] || 0) +1;
+    });
+
+    console.log(`Total unique needs: ${uniqueNeeds.length}`);
+    console.log("Region counts:", regionCounts);
+
+    console.log(`Total consolidated needs: ${consolidatedNeeds.length}`);
+    console.log(`Number of duplicates: ${duplicateNeeds.length}`);
+
+    console.log("\nDuplicate needs details:");
+    duplicateNeeds.forEach((need, index) => {
+    console.log(`\nDuplicate #${index + 1}:`);
+    console.log(`Region: ${need.region}`);
+    console.log(`Subregion: ${need.subregion}`);
+    console.log(`Product: ${JSON.stringify(need.product, null, 2)}`);
+    console.log(`Amount: ${need.amount}`);
+    console.log(`Survey: ${JSON.stringify(need.survey)}`);
+  });
+
+    return uniqueNeeds;
+}
+
+function areNeedsEqual(need1: Need, need2: Need): boolean {
+    if (!need1 || !need2) return false;
+
+    if (
+        need1.product.category !== need2.product.category ||
+        need1.product.item !== need2.product.item ||
+        need1.product.ageGender !== need2.product.ageGender ||
+        need1.product.sizeStyle !== need2.product.sizeStyle ||
+        need1.product.unit !== need2.product.unit
+    ) {
+        return false;
+    }
+
+    if (need1.amount !== need2.amount) return false;
+
+    if (
+        need1.survey.reference !== need2.survey.reference ||
+        need1.survey.year !== need2.survey.year ||
+        need1.survey.quarter !== need2.survey.quarter
+    ) {
+        return false;
+    }
+
+    if (
+        need1.region !== need2.region ||
+        need1.subregion !== need2.subregion
+    ) {
+        return false;
+    }
+
+    return true;
+}

--- a/src/scripts/import-needs-assessment-data/add-needs.ts
+++ b/src/scripts/import-needs-assessment-data/add-needs.ts
@@ -42,48 +42,46 @@ export function consolidateNeedsByRegion(
     });
 
     const uniqueNeeds: Need[] = [];
-    const duplicateNeeds: Need[] =[];
+    const duplicateNeeds: Need[] =[];   
 
     consolidatedNeeds.forEach((currentNeed) => {
-        let isDuplicate = false;
+        const existingNeedIndex = uniqueNeeds.findIndex(need =>
+            areNeedsEqual(need, currentNeed)
+        );
 
-        for (const existingNeed of uniqueNeeds) {
-            if (areNeedsEqual(currentNeed, existingNeed)) {
-                isDuplicate = true;
-                break;
-            }
-        }
-
-        if (isDuplicate) {
-            duplicateNeeds.push(currentNeed)
+        if (existingNeedIndex !==-1) {
+            duplicateNeeds.push(currentNeed);
         } else {
             uniqueNeeds.push(currentNeed);
         }
-    });    
 
-    // Print region counts for analysis after processing the data
+    });
+
+    // Gather region counts for analysis after processing the data
     const regionCounts = {};
     uniqueNeeds.forEach((need) => {
         regionCounts[need.region] = 
             (regionCounts[need.region] || 0) +1;
     });
 
-    // Logs for debugging issues with duplicates
+    // Logs for investigating the data processed
     console.log(`Total unique needs: ${uniqueNeeds.length}`);
     console.log("Region counts:", regionCounts);
 
-    console.log(`Total consolidated needs: ${consolidatedNeeds.length}`);
     console.log(`Number of duplicates: ${duplicateNeeds.length}`);
 
-    console.log("\nDuplicate needs details:");
-    duplicateNeeds.forEach((need, index) => {
-    console.log(`\nDuplicate #${index + 1}:`);
-    console.log(`Region: ${need.region}`);
-    console.log(`Subregion: ${need.subregion}`);
-    console.log(`Product: ${JSON.stringify(need.product, null, 2)}`);
-    console.log(`Amount: ${need.amount}`);
-    console.log(`Survey: ${JSON.stringify(need.survey)}`);
-  });
+    // NOTE: uncomment to view duplicates for data analysis
+    // if (duplicateNeeds.length > 0) {
+    //     console.log("\nDuplicate needs details:");
+    //     duplicateNeeds.forEach((need, index) => {
+    //     console.log(`\nDuplicate #${index + 1}:`);
+    //     console.log(`Region: ${need.region}`);
+    //     console.log(`Subregion: ${need.subregion}`);
+    //     console.log(`Product: ${JSON.stringify(need.product, null, 2)}`);
+    //     console.log(`Amount: ${need.amount}`);
+    //     console.log(`Survey: ${JSON.stringify(need.survey)}`);
+    // });
+    // }
 
     return uniqueNeeds;
 }
@@ -114,4 +112,6 @@ function areNeedsEqual(need1: Need, need2: Need): boolean {
     if (need1.region !== need2.region) return false;
 
     if (need1.subregion !== need2.subregion) return false;
+
+    return true;
 }

--- a/src/scripts/import-needs-assessment-data/index.ts
+++ b/src/scripts/import-needs-assessment-data/index.ts
@@ -7,6 +7,7 @@ import { addSubregions } from "./add-subregions";
 import { addSurveys } from "./add-surveys";
 import { addCategories } from "./add-categories";
 import { addProducts } from "./add-items";
+import { consolidateNeedsByRegion } from "./add-needs";
 
 async function main() {
   try {
@@ -14,15 +15,12 @@ async function main() {
     const jsonData = readFileSync(join(__dirname, "./needs-data(8).json"), "utf8");
     const data = JSON.parse(jsonData);
 
-    const itemsWithoutProduct = data.filter(item => !item?.product);
-    console.log("Items missing product:");
-    console.log(itemsWithoutProduct);
-
     //  Process the data and upload to Strapi collections
     const _regions = await addRegions(data);
     const _subregions = await addSubregions(data);
     const _surveys = await addSurveys(data);
     const _categories = await addCategories(data);
+    const _products = await addProducts(data);
 
     // Check the number of objects in the needs array to manually compare totals
     function countObjectsInArray(data): number {
@@ -37,7 +35,9 @@ async function main() {
     const totalCountInNeeds = countObjectsInArray(data);
     console.log(`Total objects in needs array: ${totalCountInNeeds}`);
 
-    const _products = await addProducts(data);
+    const processedNeeds = consolidateNeedsByRegion(data) // check this function is working properly
+
+    // const _products = await addProducts(data);
   } catch (error) {
     console.error("Error processing needs assessment data", error);
     if (error.code === "ENOENT") {

--- a/src/scripts/import-needs-assessment-data/index.ts
+++ b/src/scripts/import-needs-assessment-data/index.ts
@@ -35,8 +35,7 @@ async function main() {
     const totalCountInNeeds = countObjectsInArray(data);
     console.log(`Total objects in needs array: ${totalCountInNeeds}`);
 
-    const processedNeeds = consolidateNeedsByRegion(data) // check this function is working properly, modify as required with progress of script
-
+    const processedNeeds = consolidateNeedsByRegion(data); // check this function is working properly, modify as required with progress of script
   } catch (error) {
     console.error("Error processing needs assessment data", error);
     if (error.code === "ENOENT") {

--- a/src/scripts/import-needs-assessment-data/index.ts
+++ b/src/scripts/import-needs-assessment-data/index.ts
@@ -12,7 +12,7 @@ import { consolidateNeedsByRegion } from "./add-needs";
 async function main() {
   try {
     //  Load the json data
-    const jsonData = readFileSync(join(__dirname, "./needs-data(8).json"), "utf8");
+    const jsonData = readFileSync(join(__dirname, "./needs-data.json"), "utf8");
     const data = JSON.parse(jsonData);
 
     //  Process the data and upload to Strapi collections
@@ -35,9 +35,8 @@ async function main() {
     const totalCountInNeeds = countObjectsInArray(data);
     console.log(`Total objects in needs array: ${totalCountInNeeds}`);
 
-    const processedNeeds = consolidateNeedsByRegion(data) // check this function is working properly
+    const processedNeeds = consolidateNeedsByRegion(data) // check this function is working properly, modify as required with progress of script
 
-    // const _products = await addProducts(data);
   } catch (error) {
     console.error("Error processing needs assessment data", error);
     if (error.code === "ENOENT") {

--- a/src/scripts/import-needs-assessment-data/index.ts
+++ b/src/scripts/import-needs-assessment-data/index.ts
@@ -11,8 +11,12 @@ import { addProducts } from "./add-items";
 async function main() {
   try {
     //  Load the json data
-    const jsonData = readFileSync(join(__dirname, "./needs-data.json"), "utf8");
+    const jsonData = readFileSync(join(__dirname, "./needs-data(8).json"), "utf8");
     const data = JSON.parse(jsonData);
+
+    const itemsWithoutProduct = data.filter(item => !item?.product);
+    console.log("Items missing product:");
+    console.log(itemsWithoutProduct);
 
     //  Process the data and upload to Strapi collections
     const _regions = await addRegions(data);


### PR DESCRIPTION
## What changed?

This pull request adds a function to consolidate the needs in the historic needs assessment data and remove duplicates before processing the data for uploading the needs to the Strapi collection. It resolves issue [#296](https://github.com/distributeaid/aggregated-public-information/issues/296).

Note: This function also gathers the needs count for each region and any duplicate information to evaluate the accuracy of data processing at this stage.

## How can you test this?

1.  Add the following [needs-data.json](https://github.com/user-attachments/files/20351840/needs-data.json) file to the `src/scripts/import-needs-assessment-data` folder
2.  Create an API key in the Strapi console for testing this feature
3.  Set up the `src/scripts/.env` file using the `.env.example` template and add your Strapi API key 
4.  Run the dev server in one terminal and `yarn script:import-needs-assessment-data` in another

You should see the data results for Geo.regions, Geo.subregions, NeedsAssessment.Survey, Product.Categories, and Product.Items, followed by the data processed for specific needs, broken down as follows:

![consolidate-needs-results](https://github.com/user-attachments/assets/cc96dd6e-bb6c-496a-a441-36de8d80dc18)

