### PR TITLE
Fix(data-ingestion): Update upload function for region and subregion 

### DIFF
--- a/src/scripts/import-needs-assessment-data/add-regions.ts
+++ b/src/scripts/import-needs-assessment-data/add-regions.ts
@@ -203,7 +203,7 @@ async function uploadRegion({
     },
     body: JSON.stringify({
       data: {
-        Name: data.region,
+        name: data.region,
       },
     }),
   });

--- a/src/scripts/import-needs-assessment-data/add-subregions.ts
+++ b/src/scripts/import-needs-assessment-data/add-subregions.ts
@@ -207,7 +207,7 @@ async function uploadSubregion({
     },
     body: JSON.stringify({
       data: {
-        Name: data.subregion,
+        name: data.subregion,
       },
     }),
   });


### PR DESCRIPTION
## What changed?

1. The upload function in `add-regions.ts` and `add-subregions.ts` is updated to reflect the lowercase lettering requirement for the name property in each Strapi collection.

Resolves [Issue #346](https://github.com/distributeaid/aggregated-public-information/issues/346) 

## How can you test this?

1. Add the following [needs-data.json](https://github.com/user-attachments/files/20471441/needs-data.json) file to the `src/scripts/import-needs-assessment-data` folder
2. Create an API key in the Strapi console for testing this feature
3. Set up the `src/scripts/.env` file using the `.env.example` template and add your Strapi API key
4. Run the dev server in one terminal and `yarn script:import-needs-assessment-data` in another

You should now see the data results for: 
- Geo.regions indicate that 6 regions have been uploaded successfully or already exist 
- Geo.subregions indicate that 20 subregions have been uploaded or already exist