### PR TITLE
feat(data-ingestion): Add a function for workflow status of needs data

### DIFF
--- a/src/scripts/import-needs-assessment-data/add-needs.ts
+++ b/src/scripts/import-needs-assessment-data/add-needs.ts
@@ -69,7 +69,7 @@ export async function addNeeds(data: NeedAssessment[]): Promise<Need[]> {
 
 /* Consolidate the Needs and remove duplicates
  * --------------------------------------------- */
-export function consolidateNeedsByRegion(data: NeedAssessment[]): Need[] {
+function consolidateNeedsByRegion(data: NeedAssessment[]): Need[] {
   const consolidatedNeeds: Need[] = [];
 
   data.forEach((assessment) => {

--- a/src/scripts/import-needs-assessment-data/add-needs.ts
+++ b/src/scripts/import-needs-assessment-data/add-needs.ts
@@ -5,15 +5,15 @@ import { isFulfilled, _isRejected } from "../_utils/promiseUtils";
 import {
   Need,
   NeedAssessment,
-    NeedUploadWorkflow,
-    NeedUploadWorkflowResults,
+  NeedUploadWorkflow,
+  NeedUploadWorkflowResults,
 } from "./types.d";
 
 // Note: Uncomment the required imports during implementation in the code.
 
 /*  Add Needs from Needs Assessment Data
  * ------------------------------------------------------- */
-export async function addNeeds (data: NeedAssessment[]): Promise<Need[]> {
+export async function addNeeds(data: NeedAssessment[]): Promise<Need[]> {
   console.log("Adding Needs from the Needs Assessment data ....");
 
   const uniqueNeedEntries = consolidateNeedsByRegion(data);
@@ -27,12 +27,11 @@ export async function addNeeds (data: NeedAssessment[]): Promise<Need[]> {
         logs: [],
       };
 
-      return Promise.resolve(initialWorkflow)
-      
+      return Promise.resolve(initialWorkflow);
     }),
   );
 
-// { "SUCCESS": [], "ALREADY_EXITS": [], ...}
+  // { "SUCCESS": [], "ALREADY_EXITS": [], ...}
   const resultsMap: NeedUploadWorkflowResults = Object.fromEntries(
     Object.keys(UploadWorkflowStatus).map((key) => [key, []]),
   ) as NeedUploadWorkflowResults;
@@ -65,7 +64,7 @@ export async function addNeeds (data: NeedAssessment[]): Promise<Need[]> {
     return [...needs, workflow.data];
   }, [] as Need[]);
 
-  return validNeeds;  
+  return validNeeds;
 }
 
 /* Consolidate the Needs and remove duplicates

--- a/src/scripts/import-needs-assessment-data/index.ts
+++ b/src/scripts/import-needs-assessment-data/index.ts
@@ -7,7 +7,7 @@ import { addSubregions } from "./add-subregions";
 import { addSurveys } from "./add-surveys";
 import { addCategories } from "./add-categories";
 import { addProducts } from "./add-items";
-import { consolidateNeedsByRegion } from "./add-needs";
+import { addNeeds } from "./add-needs";
 
 async function main() {
   try {
@@ -35,7 +35,7 @@ async function main() {
     const totalCountInNeeds = countObjectsInArray(data);
     console.log(`Total objects in needs array: ${totalCountInNeeds}`);
 
-    const _processedNeeds = consolidateNeedsByRegion(data); // check this function is working properly, modify as required with progress of script
+    const _needs = await addNeeds(data);
   } catch (error) {
     console.error("Error processing needs assessment data", error);
     if (error.code === "ENOENT") {

--- a/yarn.lock
+++ b/yarn.lock
@@ -19811,13 +19811,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"regenerator-runtime@npm:^0.14.0":
-  version: 0.14.1
-  resolution: "regenerator-runtime@npm:0.14.1"
-  checksum: 10c0/1b16eb2c4bceb1665c89de70dcb64126a22bc8eb958feef3cd68fe11ac6d2a4899b5cd1b80b0774c7c03591dc57d16631a7f69d2daa2ec98100e2f29f7ec4cc4
-  languageName: node
-  linkType: hard
-
 "regex-not@npm:^1.0.0, regex-not@npm:^1.0.2":
   version: 1.0.2
   resolution: "regex-not@npm:1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -19811,6 +19811,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"regenerator-runtime@npm:^0.14.0":
+  version: 0.14.1
+  resolution: "regenerator-runtime@npm:0.14.1"
+  checksum: 10c0/1b16eb2c4bceb1665c89de70dcb64126a22bc8eb958feef3cd68fe11ac6d2a4899b5cd1b80b0774c7c03591dc57d16631a7f69d2daa2ec98100e2f29f7ec4cc4
+  languageName: node
+  linkType: hard
+
 "regex-not@npm:^1.0.0, regex-not@npm:^1.0.2":
   version: 1.0.2
   resolution: "regex-not@npm:1.0.2"


### PR DESCRIPTION
## What changed?

This pull request adds a function to view the workflow status of the historic needs data processing during data transfer of the needs to the NeedsAssessment.Need collection. It resolves [#297](https://github.com/distributeaid/aggregated-public-information/issues/297).

Note: The region counts and duplicate details have been left for viewing to monitor the accuracy of data processing at this stage.

## How can you test this?
1. Add the following [needs-data.json](https://github.com/user-attachments/files/20579847/needs-data.json) file to the `src/scripts/import-needs-assessment-data` folder
2. Create an API key in the Strapi console for testing this feature
3. Set up the `src/scripts/.env` file using the `src/scripts/.env.example` template and add your Strapi API key
4. Run the dev server in one terminal and `yarn script:import-needs-assessment-data` in another

You should see the following data results appear after the Geo.regions, Geo.subregions, NeedsAssessment.Survey, Product.Categories, and Product.Items results:

![workflow-status-needs](https://github.com/user-attachments/assets/9cbdbb29-5bb4-4dff-bcc8-c21c1ae8778f)
