### PR TITLE
feat(data-ingestion): Add a parse function to the add-needs script

### DIFF
--- a/src/scripts/import-needs-assessment-data/add-needs.ts
+++ b/src/scripts/import-needs-assessment-data/add-needs.ts
@@ -27,8 +27,7 @@ export async function addNeeds(data: NeedAssessment[]): Promise<Need[]> {
         logs: [],
       };
 
-      return Promise.resolve(initialWorkflow)
-      .then(parseNeeds);
+      return Promise.resolve(initialWorkflow).then(parseNeeds);
     }),
   );
 
@@ -169,7 +168,7 @@ function areNeedsEqual(need1: Need, need2: Need): boolean {
 }
 
 /*  Parse Needs
-* --------------------------------------------------- */
+ * --------------------------------------------------- */
 async function parseNeeds({
   data,
   orig,
@@ -194,7 +193,9 @@ async function parseNeeds({
     const parsedData: Need[] = [];
 
     needs.forEach((need) => {
-      logs.push(`Parsing need: ${need.region} | ${need.product} | ${need.amount}`);
+      logs.push(
+        `Parsing need: ${need.region} | ${need.product} | ${need.amount}`,
+      );
 
       if (!need.survey || !need.product) {
         throw {

--- a/src/scripts/import-needs-assessment-data/add-needs.ts
+++ b/src/scripts/import-needs-assessment-data/add-needs.ts
@@ -27,7 +27,8 @@ export async function addNeeds(data: NeedAssessment[]): Promise<Need[]> {
         logs: [],
       };
 
-      return Promise.resolve(initialWorkflow);
+      return Promise.resolve(initialWorkflow)
+      .then(parseNeeds);
     }),
   );
 
@@ -165,4 +166,59 @@ function areNeedsEqual(need1: Need, need2: Need): boolean {
   if (need1.subregion !== need2.subregion) return false;
 
   return true;
+}
+
+/*  Parse Needs
+* --------------------------------------------------- */
+async function parseNeeds({
+  data,
+  orig,
+  status,
+  logs,
+}: NeedUploadWorkflow): Promise<NeedUploadWorkflow> {
+  logs = [...logs, `Log: parsing needs...`];
+
+  const needs = (() => {
+    if (typeof data === "object" && data !== null) {
+      if (Array.isArray(data)) {
+        return data;
+      } else if (Object.hasOwn(data, "need")) {
+        return [(data as Record<string, unknown>).need as Need];
+      }
+    }
+    console.log("Unexpected object structure:", JSON.stringify(data));
+    return [];
+  })();
+
+  return new Promise<NeedUploadWorkflow>((resolve, _reject) => {
+    const parsedData: Need[] = [];
+
+    needs.forEach((need) => {
+      logs.push(`Parsing need: ${need.region} | ${need.product} | ${need.amount}`);
+
+      if (!need.survey || !need.product) {
+        throw {
+          data,
+          orig,
+          status: UploadWorkflowStatus.ORIGINAL_DATA_INVALID,
+          logs: [
+            ...logs,
+            `Error: Invalid need input: "${need.region}-${need.product}". Expected a non-null value in survey and product.`,
+          ],
+        };
+      }
+
+      const processedNeed: Need = {
+        ...need,
+      };
+      parsedData.push(processedNeed);
+    });
+
+    resolve({
+      data: parsedData,
+      orig,
+      status,
+      logs,
+    });
+  });
 }


### PR DESCRIPTION
## What changed?

This pull request adds a parse function to remove invalid data from the historic needs during processing. It resolves [#298](https://github.com/distributeaid/aggregated-public-information/issues/298).

Note: The current parse function **keeps** needs in the data for "undefined" regions. This requires that an entry for "Other" be created in the Geo.region collection to allow for these specific needs to be uploaded to the NeedsAssessment.Need collection.

## How can you test this?

1. Add the following [needs-data.json](https://github.com/user-attachments/files/20779387/needs-data.json) file to the `src/scripts/import-needs-assessment-data` folder
2. Create an API key in the Strapi console for testing this feature
3. Set up the `src/scripts/.env` file using the `src/scripts/.env.example` template and add your Strapi API key
4. Run the dev server in one terminal and `yarn script:import-needs-assessment-data` in another

You should see the following data results appear after the Geo.regions, Geo.subregions, NeedsAssessment.Survey, Product.Categories, and Product.Items results:
![parse-function](https://github.com/user-attachments/assets/e7b38907-9aa8-4547-a7f1-15a4c9484f24)


** A second manual test to ensure the parse function is working is to change the current requirements in line 200 of the `add-needs.ts` file to reflect the removal of data that does not include a region, as seen in the following image:
![parse-function_noregion](https://github.com/user-attachments/assets/a809129a-ad86-4c4e-a81a-feb9e0eba2b5)


This then changes the results to reflect that modification, as seen below:
![pares-function_noregion(results)](https://github.com/user-attachments/assets/d63b9fea-c350-4a61-b502-82a9bf91e3c9)

