### PR TITLE
Feat/299/working branch needs data fetch ids

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -13,4 +13,4 @@ src/extensions/documentation
 
 # Ignore specific files that currently cause an E2BIG error when formatted:
 src/scripts/import-needs-assessment-data/get-ids.ts
-src/scripts/import-needs-assessment-data/add-collections.ts
+src/scripts/import-needs-assessment-data/add-collection-ids.ts

--- a/.prettierignore
+++ b/.prettierignore
@@ -11,3 +11,6 @@ types/generated/*
 src/api/*/documentation
 src/extensions/documentation
 
+# Ignore specific files that currently cause an E2BIG error when formatted:
+src/scripts/import-needs-assessment-data/get-ids.ts
+src/scripts/import-needs-assessment-data/add-collections.ts

--- a/src/scripts/import-needs-assessment-data/add-collection-ids.ts
+++ b/src/scripts/import-needs-assessment-data/add-collection-ids.ts
@@ -7,7 +7,8 @@ import {
 export async function addCollectionIdsToData(
   data: NeedAssessment[],
   regionResults,
-  subregionResults
+  subregionResults,
+  surveyResults
 ): Promise<Need[]> {
   const processedData: Need[] = [];
   
@@ -15,10 +16,18 @@ export async function addCollectionIdsToData(
   const regionIdMap = new Map(
     regionResults.map(region => [region.name.toLowerCase(), region.id])
   );
-  console.log(regionIdMap);
+  console.log(regionIdMap); // log map to test
   const subregionIdMap = new Map(
     subregionResults.map(subregion => [subregion.name.toLowerCase(), subregion.id])
   );
+  console.log(subregionIdMap); // log map to test
+  const surveyIdMap = new Map(
+    surveyResults.map(survey => [
+      `${survey.reference} | ${survey.yearQuarter}`,
+      survey.id
+    ])
+  );
+  console.log(surveyIdMap); // log map to test
   
   for (const assessment of data) {
     try {
@@ -42,6 +51,8 @@ export async function addCollectionIdsToData(
         subregionId: assessment.place.subregion
           ? Number(subregionIdMap.get(assessment.place.subregion.toLowerCase()) || 0)
           : 0,
+        surveyId: Number(surveyIdMap.get(
+          `${assessment.survey.id} | ${assessment.survey.year}-${assessment.survey.quarter}`) || 0),
       };
       
       if (!processedNeed.regionId) {
@@ -49,6 +60,9 @@ export async function addCollectionIdsToData(
       }
       if (assessment.place.subregion && !processedNeed.subregionId) {
         console.warn(`No subregion ID found for subregion: ${assessment.place.subregion}`);
+      }
+      if (assessment.survey.id && !processedNeed.surveyId) {
+        console.warn(`No survey ID found for survey: ${assessment.survey.id} | ${assessment.survey.year}-${assessment.survey.quarter}`);
       }
       
       processedData.push(processedNeed);

--- a/src/scripts/import-needs-assessment-data/add-collection-ids.ts
+++ b/src/scripts/import-needs-assessment-data/add-collection-ids.ts
@@ -1,0 +1,60 @@
+import { 
+    NeedAssessment,
+    Need
+} from './types';
+// import { getRegionIds, getSubregionIds } from "./get-ids";
+
+export async function addCollectionIdsToData(
+  data: NeedAssessment[],
+  regionResults,
+  subregionResults
+): Promise<Need[]> {
+  const processedData: Need[] = [];
+  
+  // Create maps for the collections required
+  const regionIdMap = new Map(
+    regionResults.map(region => [region.name.toLowerCase(), region.id])
+  );
+  const subregionIdMap = new Map(
+    subregionResults.map(subregion => [subregion.name.toLowerCase(), subregion.id])
+  );
+  
+  for (const assessment of data) {
+    try {
+      const processedNeed: Need = {
+        product: {
+          category: assessment.product.category,
+          item: assessment.product.item,
+          ageGender: assessment.product.ageGender || "",
+          sizeStyle: assessment.product.sizeStyle || "",
+          unit: assessment.product.unit || "",
+        },
+        amount: assessment.need,
+        survey: {
+          reference: assessment.survey.id,
+          year: assessment.survey.year,
+          quarter: assessment.survey.quarter,
+        },
+        region: assessment.place.region,
+        subregion: assessment.place.subregion || "",
+        regionId: Number(regionIdMap.get(assessment.place.region.toLowerCase()) || 0),
+        subregionId: assessment.place.subregion
+          ? Number(subregionIdMap.get(assessment.place.subregion.toLowerCase()) || 0)
+          : 0,
+      };
+      
+      if (!processedNeed.regionId) {
+        console.warn(`No region ID found for region: ${assessment.place.region}`);
+      }
+      if (assessment.place.subregion && !processedNeed.subregionId) {
+        console.warn(`No subregion ID found for subregion: ${assessment.place.subregion}`);
+      }
+      
+      processedData.push(processedNeed);
+    } catch (error) {
+      console.error(`Error processing assessment: ${error.message}`);
+    }
+  }
+  
+  return processedData;
+}

--- a/src/scripts/import-needs-assessment-data/add-collection-ids.ts
+++ b/src/scripts/import-needs-assessment-data/add-collection-ids.ts
@@ -15,6 +15,7 @@ export async function addCollectionIdsToData(
   const regionIdMap = new Map(
     regionResults.map(region => [region.name.toLowerCase(), region.id])
   );
+  console.log(regionIdMap);
   const subregionIdMap = new Map(
     subregionResults.map(subregion => [subregion.name.toLowerCase(), subregion.id])
   );

--- a/src/scripts/import-needs-assessment-data/add-collection-ids.ts
+++ b/src/scripts/import-needs-assessment-data/add-collection-ids.ts
@@ -16,18 +16,18 @@ export async function addCollectionIdsToData(
   const regionIdMap = new Map(
     regionResults.map(region => [region.name.toLowerCase(), region.id])
   );
-  console.log(regionIdMap); // log map to test
+  // console.log(regionIdMap); // log map to test
   const subregionIdMap = new Map(
     subregionResults.map(subregion => [subregion.name.toLowerCase(), subregion.id])
   );
-  console.log(subregionIdMap); // log map to test
+  // console.log(subregionIdMap); // log map to test
   const surveyIdMap = new Map(
     surveyResults.map(survey => [
       `${survey.reference} | ${survey.yearQuarter}`,
       survey.id
     ])
   );
-  console.log(surveyIdMap); // log map to test
+  // console.log(surveyIdMap); // log map to test
   
   for (const assessment of data) {
     try {
@@ -45,9 +45,9 @@ export async function addCollectionIdsToData(
           year: assessment.survey.year,
           quarter: assessment.survey.quarter,
         },
-        region: assessment.place.region,
+        region: assessment.place.region ?? "other",
         subregion: assessment.place.subregion || "",
-        regionId: Number(regionIdMap.get(assessment.place.region.toLowerCase()) || 0),
+        regionId: Number(regionIdMap.get((assessment.place.region ?? "other").toLowerCase()) || 0),
         subregionId: assessment.place.subregion
           ? Number(subregionIdMap.get(assessment.place.subregion.toLowerCase()) || 0)
           : 0,

--- a/src/scripts/import-needs-assessment-data/add-needs.ts
+++ b/src/scripts/import-needs-assessment-data/add-needs.ts
@@ -28,8 +28,8 @@ export async function addNeeds(data: NeedAssessment[]): Promise<Need[]> {
       };
 
       return Promise.resolve(initialWorkflow)
-      .then(parseNeeds)
-      .then(getRegionIds);
+        .then(parseNeeds)
+        .then(getRegionIds);
     }),
   );
 
@@ -226,18 +226,15 @@ async function parseNeeds({
   });
 }
 
-/**  Get Region Ids 
-*  *********************************************/
+/**  Get Region Ids
+ *  *********************************************/
 async function getRegionIds({
   data,
   orig,
   status,
   logs,
 }: NeedUploadWorkflow): Promise<NeedUploadWorkflow> {
-  logs = [
-    ...logs,
-    `Log: Getting the region Id for "${data[0].region}".`,
-  ];
+  logs = [...logs, `Log: Getting the region Id for "${data[0].region}".`];
 
   const response = await fetch(`${STRAPI_ENV.URL}/regions`, {
     method: "GET",
@@ -279,9 +276,6 @@ async function getRegionIds({
     data,
     orig,
     status,
-    logs: [
-      ...logs,
-      "Success: Confirmed Need has a matching region Id.",
-    ],
+    logs: [...logs, "Success: Confirmed Need has a matching region Id."],
   };
 }

--- a/src/scripts/import-needs-assessment-data/get-ids.ts
+++ b/src/scripts/import-needs-assessment-data/get-ids.ts
@@ -3,7 +3,6 @@ import { STRAPI_ENV } from "../strapi-env";
 /*  Get the ids for each region from Strapi
  * ------------------------------------------------------- */
 async function getRegionIds() {
-  // const regionResponse = await fetch(`${STRAPI_ENV.URL}/regions`, {
   const existingRegions = await fetch(`${STRAPI_ENV.URL}/regions`, {
     method: "GET",
     headers: {
@@ -45,6 +44,8 @@ async function getRegionIds() {
 
 export { getRegionIds };
 
+/*  Get the ids for each subregion from Strapi
+ * ------------------------------------------------------- */
 async function getSubregionIds() {
   const subregionResponse = await fetch(`${STRAPI_ENV.URL}/subregions`, {
     method: "GET",
@@ -60,6 +61,8 @@ async function getSubregionIds() {
 
 export { getSubregionIds };
 
+/*  Get the ids for each survey from Strapi
+ * ------------------------------------------------------- */
 async function getSurveyIds() {
   const surveyResponse = await fetch(`${STRAPI_ENV.URL}/surveys`, {
     method: "GET",
@@ -75,17 +78,84 @@ async function getSurveyIds() {
 
 export { getSurveyIds };
 
+/*  Get the ids for each product item from Strapi
+ * ------------------------------------------------------- */
 async function getProductItemIds() {
-  const productItemResponse = await fetch(`${STRAPI_ENV.URL}/items`, {
-    method: "GET",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${STRAPI_ENV.KEY}`,
-    },
-  });
+  const allItems = [];
+  let currentPage = 1;
+  let totalPages = 0;
 
-  const productItemResults = await productItemResponse.json();
-  return productItemResults.data;
+  // console.log('➡️ Inital array length:', allItems.length)
+
+  do {
+    try {
+      const productItemResponse = await fetch(`${STRAPI_ENV.URL}/items?pagination[page]=${currentPage}&pagination[pageSize]=25`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${STRAPI_ENV.KEY}`,
+      },
+    });
+
+    if (!productItemResponse.ok) {
+      throw new Error(`HTTP error! status: ${productItemResponse.status}`);
+    }
+
+    const data = await productItemResponse.json();
+    
+    // Debugging the items coming in via the page
+    // console.log(`➡️ Page ${currentPage}`);
+    // console.log('➡️ Pagination metadata:', data.meta.pagination);
+    // console.log('➡️ Items received on this page:', data.data.length);
+
+    if (!data || !data.data) {
+      throw new Error('Invalid response structure: product item data is missing');
+    }
+
+    if (!Array.isArray(data.data)) {
+      throw new Error('Invalid response structure: product item data is not an array');
+    }
+
+    // checking for duplicates before adding to the allItems array
+    const newItems = data.data.filter(item =>
+      !allItems.some(existing => existing.id === item.id)
+    );
+
+    // Debugging for items issue
+    // const previousLength = allItems.length;
+    allItems.push(...newItems);
+    // const newLength = allItems.length;
+    // console.log('Array length after pushing new items:', newLength);
+    // console.log('Items added in this iteration:', newLength - previousLength);
+
+    //verify no duplicates in current page
+    const currentPageIds = new Set(data.data.map(item => item.id));
+    if (currentPageIds.size !== data.data.length) {
+      console.warn('Warning: Duplicate items detected in current page!');
+    }
+
+    totalPages = data.meta.pagination.pageCount;
+    currentPage++;
+
+    } catch (error) {
+      console.error(`Error fetching page ${currentPage}:`, error);
+      throw error;
+    }
+    
+  } while (currentPage <= totalPages);
+
+  // final verification that the allItems array does not contain duplicates
+  const finalIds = new Set(allItems.map(item => item.id));
+
+  console.log('Final array length:', allItems.length);
+  console.log('Number of unique items:', finalIds.size);
+
+// console.log('\nFull array contents:');
+// allItems.forEach((item, index) => {
+//     console.log(`${index}:`, item);
+// });
+
+  return allItems;
 }
 
 export { getProductItemIds };

--- a/src/scripts/import-needs-assessment-data/get-ids.ts
+++ b/src/scripts/import-needs-assessment-data/get-ids.ts
@@ -1,0 +1,91 @@
+import { STRAPI_ENV } from "../strapi-env";
+
+/*  Get the ids for each region from Strapi
+ * ------------------------------------------------------- */
+async function getRegionIds() {
+  // const regionResponse = await fetch(`${STRAPI_ENV.URL}/regions`, {
+  const existingRegions = await fetch(`${STRAPI_ENV.URL}/regions`, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${STRAPI_ENV.KEY}`,
+    },
+  });
+
+  const regionsResponse = await existingRegions.json();
+
+  // Check if "Other" region exists
+  if (!regionsResponse.data?.some(region => region.attributes?.name === "Other")) {
+    // Add "Other" region if it's missing
+    await fetch(`${STRAPI_ENV.URL}/regions`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${STRAPI_ENV.KEY}`,
+      },
+      body: JSON.stringify({
+        data: {
+          name: "Other",
+        }
+      }),
+    });
+    
+    // Re-fetch to ensure the new "Other" region is included
+    return await fetch(`${STRAPI_ENV.URL}/regions`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${STRAPI_ENV.KEY}`,
+      },
+    }).then(r => r.json()).then(r => r.data);
+  }
+
+  return regionsResponse.data;
+}
+
+export { getRegionIds };
+
+async function getSubregionIds() {
+  const subregionResponse = await fetch(`${STRAPI_ENV.URL}/subregions`, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${STRAPI_ENV.KEY}`,
+    },
+  });
+
+  const subregionResults = await subregionResponse.json();
+  return subregionResults.data;
+}
+
+export { getSubregionIds };
+
+async function getSurveyIds() {
+  const surveyResponse = await fetch(`${STRAPI_ENV.URL}/surveys`, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${STRAPI_ENV.KEY}`,
+    },
+  });
+
+  const surveyResults = await surveyResponse.json();
+  return surveyResults.data;
+}
+
+export { getSurveyIds };
+
+async function getProductItemIds() {
+  const productItemResponse = await fetch(`${STRAPI_ENV.URL}/items`, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${STRAPI_ENV.KEY}`,
+    },
+  });
+
+  const productItemResults = await productItemResponse.json();
+  return productItemResults.data;
+}
+
+export { getProductItemIds };

--- a/src/scripts/import-needs-assessment-data/index.ts
+++ b/src/scripts/import-needs-assessment-data/index.ts
@@ -9,11 +9,12 @@ import { addCategories } from "./add-categories";
 import { addProducts } from "./add-items";
 //import { addNeeds } from "./add-needs";
 import { getRegionIds, getSubregionIds, getSurveyIds, getProductItemIds } from "./get-ids";
+import { addCollectionIdsToData } from "./add-collection-ids";
 
 async function main() {
   try {
     //  Load the json data
-    const jsonData = readFileSync(join(__dirname, "./needs-data.json"), "utf8");
+    const jsonData = readFileSync(join(__dirname, "./needs-data(subset).json"), "utf8");
     const data = JSON.parse(jsonData);
 
     //  Process the data and upload to Strapi collections
@@ -44,6 +45,10 @@ async function main() {
     console.log("Surveys data", surveyResults.length); // Log survey results for test
     const productItemResults = await getProductItemIds();
     console.log("Product Items data", productItemResults.length); // Log product item results for test
+
+    const processedData = await addCollectionIdsToData(data, regionResults, subregionResults);
+    console.log(processedData);
+    console.log("Processed needs:", processedData.length);
 
     //const _needs = await addNeeds(data);
   } catch (error) {

--- a/src/scripts/import-needs-assessment-data/index.ts
+++ b/src/scripts/import-needs-assessment-data/index.ts
@@ -14,7 +14,7 @@ import { addCollectionIdsToData } from "./add-collection-ids";
 async function main() {
   try {
     //  Load the json data
-    const jsonData = readFileSync(join(__dirname, "./needs-data(subset).json"), "utf8");
+    const jsonData = readFileSync(join(__dirname, "./needs-data.json"), "utf8");
     const data = JSON.parse(jsonData);
 
     //  Process the data and upload to Strapi collections

--- a/src/scripts/import-needs-assessment-data/index.ts
+++ b/src/scripts/import-needs-assessment-data/index.ts
@@ -7,7 +7,8 @@ import { addSubregions } from "./add-subregions";
 import { addSurveys } from "./add-surveys";
 import { addCategories } from "./add-categories";
 import { addProducts } from "./add-items";
-import { addNeeds } from "./add-needs";
+//import { addNeeds } from "./add-needs";
+import { getRegionIds, getSubregionIds, getSurveyIds, getProductItemIds } from "./get-ids";
 
 async function main() {
   try {
@@ -35,7 +36,16 @@ async function main() {
     const totalCountInNeeds = countObjectsInArray(data);
     console.log(`Total objects in needs array: ${totalCountInNeeds}`);
 
-    const _needs = await addNeeds(data);
+    const regionResults = await getRegionIds();
+    console.log("Regions data", regionResults.length); // Log region results for test
+    const subregionResults = await getSubregionIds();
+    console.log("Subregions data", subregionResults.length); // Log subregion results for test
+    const surveyResults = await getSurveyIds();
+    console.log("Surveys data", surveyResults.length); // Log survey results for test
+    const productItemResults = await getProductItemIds();
+    console.log("Product Items data", productItemResults.length); // Log product item results for test
+
+    //const _needs = await addNeeds(data);
   } catch (error) {
     console.error("Error processing needs assessment data", error);
     if (error.code === "ENOENT") {

--- a/src/scripts/import-needs-assessment-data/index.ts
+++ b/src/scripts/import-needs-assessment-data/index.ts
@@ -46,7 +46,7 @@ async function main() {
     const productItemResults = await getProductItemIds();
     console.log("Product Items data", productItemResults.length); // Log product item results for test
 
-    const processedData = await addCollectionIdsToData(data, regionResults, subregionResults);
+    const processedData = await addCollectionIdsToData(data, regionResults, subregionResults, surveyResults);
     console.log(processedData);
     console.log("Processed needs:", processedData.length);
 

--- a/src/scripts/import-needs-assessment-data/index.ts
+++ b/src/scripts/import-needs-assessment-data/index.ts
@@ -47,7 +47,7 @@ async function main() {
     console.log("Product Items data", productItemResults.length); // Log product item results for test
 
     const processedData = await addCollectionIdsToData(data, regionResults, subregionResults, surveyResults);
-    console.log(processedData);
+    // console.log(processedData);
     console.log("Processed needs:", processedData.length);
 
     //const _needs = await addNeeds(data);

--- a/src/scripts/import-needs-assessment-data/index.ts
+++ b/src/scripts/import-needs-assessment-data/index.ts
@@ -8,7 +8,12 @@ import { addSurveys } from "./add-surveys";
 import { addCategories } from "./add-categories";
 import { addProducts } from "./add-items";
 //import { addNeeds } from "./add-needs";
-import { getRegionIds, getSubregionIds, getSurveyIds, getProductItemIds } from "./get-ids";
+import {
+  getRegionIds,
+  getSubregionIds,
+  getSurveyIds,
+  getProductItemIds,
+} from "./get-ids";
 import { addCollectionIdsToData } from "./add-collection-ids";
 
 async function main() {
@@ -46,7 +51,12 @@ async function main() {
     const productItemResults = await getProductItemIds();
     console.log("Product Items data", productItemResults.length); // Log product item results for test
 
-    const processedData = await addCollectionIdsToData(data, regionResults, subregionResults, surveyResults);
+    const processedData = await addCollectionIdsToData(
+      data,
+      regionResults,
+      subregionResults,
+      surveyResults,
+    );
     // console.log(processedData);
     console.log("Processed needs:", processedData.length);
 

--- a/src/scripts/import-needs-assessment-data/types.d.ts
+++ b/src/scripts/import-needs-assessment-data/types.d.ts
@@ -34,7 +34,9 @@ export type Need = {
     quarter: string;
   };
   region: string;
+  regionId?: number;
   subregion?: string;
+  subregionId?: number;
   product: {
     category: string;
     item: string;

--- a/src/scripts/import-needs-assessment-data/types.d.ts
+++ b/src/scripts/import-needs-assessment-data/types.d.ts
@@ -34,9 +34,7 @@ export type Need = {
     quarter: string;
   };
   region: string;
-  regionId?: number;
   subregion?: string;
-  subregionId?: number;
   product: {
     category: string;
     item: string;
@@ -45,6 +43,10 @@ export type Need = {
     unit?: string;
   };
   amount: number;
+  regionId?: number;
+  subregionId?: number;
+  surveyId?: number;
+  productId?: number;
 };
 
 export type NeedAssessment = {


### PR DESCRIPTION
## What changed?
This draft pull request serves as an example of the code in a working state. The goal is to retrieve the IDs for relation fields in the needs data and add those IDs to the data being processed. This is required before checking if the need already exists in the NeedsAssessment.Need collection and for final upload of the need to the Strapi collection. This will resolve https://github.com/distributeaid/aggregated-public-information/issues/299 and https://github.com/distributeaid/aggregated-public-information/issues/354.

The following relation fields require IDs to process:

- region (achieved)
- subregion (achieved)
- survey (achieved)
- product item - IN PROGRESS

This branch shows the code that works in the current state, without the E2BIG error that occurs after merging saga into this feature branch (as seen in [PR#388](https://github.com/distributeaid/aggregated-public-information/pull/388)). The branch currently has the following files: `src/scripts/import-needs-assessment-data/get-ids.ts` and `src/scripts/import-needs-assessment-data/add-collection-ids.ts` ignored during formatting. Formatting those files also causes the E2BIG error to occur.

## How can you test this?

1. Add the following [needs-data.json](https://github.com/user-attachments/files/22030657/needs-data.json) file to the `src/scripts/import-needs-assessment-data` folder
2. Create an API key in the Strapi console for testing this feature
3. Set up the `src/scripts/.env` file using the `src/scripts/.env.example` template and add your Strapi API key
4. Run the dev server in one terminal and `yarn script:import-needs-assessment-data` in another

Here are images of the console with the code working as expected:

<img width="585" height="250" alt="relation-field-arrays-copy" src="https://github.com/user-attachments/assets/e974e71f-e63f-4b5d-b95f-e93f72b649c8" />

The above image shows the count for each relational field array required in the needs.

<img width="732" height="144" alt="processed-data-with-ids" src="https://github.com/user-attachments/assets/b7e21669-dc88-4f21-8f71-f48331a5ad50" />

The above image shows the error messages for each need that does not have a survey ID and the final count for the processed needs.
