### PR TITLE
fix/521/ update readme with working contributing to DA link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # README
 
-This project uses [Strapi](https://strapi.io) as a CMS backend. For most information about contributing to DA (e.g. our dev process and asking for help), please refer to the [general DA contributing guide](https://github.com/distributeaid/docs/blob/193d6eaaedb5b9e453f97ae15619d07e6b1e7ba1/how-to-DA/CONTRIBUTING.md). This guide contains other information specific to contributing to this repo.
+This project uses [Strapi](https://strapi.io) as a CMS backend. For most information about contributing to DA (e.g. our dev process and asking for help), please refer to the [general DA contributing guide](https://github.com/distributeaid/docs/blob/main/how-to-DA/CONTRIBUTING.md). This guide contains other information specific to contributing to this repo.
 
 ## Table of Contents
 


### PR DESCRIPTION
Fixes #521

## What changed?

The link to the **general DA contributing guide** in the repo README intro has been updated to a working link.

## How can you test this?
Click the link to view the docs.

Resolves [Issue#521](https://github.com/distributeaid/aggregated-public-information/issues/521)