### PR TITLE
ci/noissue/adding prod secrets

### DIFF
--- a/.environments/prod.secrets.enc.yaml
+++ b/.environments/prod.secrets.enc.yaml
@@ -1,0 +1,68 @@
+#ENC[AES256_GCM,data:sls+AQ==,iv:czKlHv+l9PwqK00mQfcKV1Y3sSCnmte/7aN8yPjju+o=,tag:KJ+VpTNaJYT8GuRHJFnTuw==,type:comment]
+HOST: ENC[AES256_GCM,data:ErlfW5byWg==,iv:k859s37bvQexJE9Dn278rNOqCjJx57b9UNN4m1I5UwQ=,tag:Vuthhhlb+rcrCg/ka8lJEg==,type:str]
+PORT: ENC[AES256_GCM,data:lfb8ww==,iv:T1Y2hN4pa3sVv43AF8cYVR+T2B9xlQAOdWrnqu2zWQU=,tag:4cdCBSCcgXE1EdYyWwItiA==,type:int]
+APP_URL: ENC[AES256_GCM,data:GvMeD1C1agt1n8eaEQx2HWgF3sTFa/7HHsP/hvE=,iv:nqvphnbP0RmBi/ID+Po43ViBnoGp0RoIuBUr1+JZXvw=,tag:Juo5UVymsJJOnFO+FSKRpQ==,type:str]
+#ENC[AES256_GCM,data:W13PhFfd5A==,iv:gNmkIEzJDYP5/pFse4+7y+nIadA9BGX4FRZ8I4YgPds=,tag:cZX1JVM65jjo8ifulI+LMg==,type:comment]
+#ENC[AES256_GCM,data:eO4zmX1H5jUF1pnyZ8zK0Y3b+hglBXHshfyfAgUCOPFBzVLO+sgMZjtnY0EhyCawsWHt,iv:7JN4TODX+6VEcXOSzbKkGQylNEA06ABbqW5tbA2Crgw=,tag:ppbY1/+fkuBdlNnIKlqqmg==,type:comment]
+APP_KEYS: ENC[AES256_GCM,data:8jKI1zqQpW8e9YlNR60Rlc82eZvTO+tUmXT4EYta/wXZL8XLunXjEE05ttZzdMMsChUduSoXVN5LGp1BMcwd/8FumOenxayOR9WQLmiGmdIh6DBOqilBIxeNM8okgG2hdhiY,iv:D8D5gMQqEfp8OARIBzE28AAbYSgz81u2Fba2Snl3tQk=,tag:4gOv3sKQVg0rZkVYApa31g==,type:str]
+API_TOKEN_SALT: ENC[AES256_GCM,data:BnGUL5wIXo04ww8YQvN3Nfz80TAOQwdB,iv:Q9dxkNUysTrB/dxdohuxYDm/UsSCxTZ7ZWZIbhZx3uI=,tag:4X+5sLadf6txfO6VGpY3BA==,type:str]
+ADMIN_JWT_SECRET: ENC[AES256_GCM,data:bXQNI6x/kmENpx4/WInOL657AdUCRSI9,iv:+yOBfdfrAlGfef67W0gK5+VtIvJQ8gRrYdoYtHTvNQw=,tag:YHSE2vM82y+3qzyC+rACUg==,type:str]
+JWT_SECRET: ENC[AES256_GCM,data:0AONXkxYUWNDuvYixzqRqnToh5Os+CJQ,iv:zItJxAjfs+eJWH6002J3gh41DR6Z4nLS1N9h5xJuoN4=,tag:M3PZLxqJToZ9A2T1ERWtlA==,type:str]
+TRANSFER_TOKEN_SALT: ENC[AES256_GCM,data:ozI6k6qdyan50fk+jMtBWk6XcYxNjcdg,iv:1rRTxLL4FfcigpDFr9uTIq9WNe5nQdgjBpHM6qQ9LYk=,tag:hd6YKMc2O1rX/i7BbGl+bQ==,type:str]
+STRAPI_URL: ENC[AES256_GCM,data:Sguh73KRgkwx+gb+Ff93bvbs0DeU,iv:6H1YpiUpbk56NxvjBTX5Nh8ICI+bSy1K6wBWLmq+F0s=,tag:O/2rMiAml/B4iqbLMSfn3Q==,type:str]
+STRAPI_API_KEY: ENC[AES256_GCM,data:UxeC5etFsF+DEMzCig8H88jZrxkTdvBi227qj9ZOiS48/KZ1fgW4xIvR9+59RBQ+/BHkW0LsfRg7em+J+tRPWfJWEsgrbkyI5mYI3JDWOMn7jmUb7YiA+ygEu1/g4RXKc0KdsLTQVwoHOS5ZLA+8Tv+ycg4OpEF7xme2WCIc8MmhnBEHGB0crS9DLT59+gh94jxVuMxM71QfpmqSsCQNjCAS5Pe8++cmR41SGQnAh7ZZ782sAltqKm8EI/9iHDyyv/Llb7YZI51z1W3QqaYs9aaKtR6SW5ZhHuSCY94+2zPDQ2jtw53o11tokFcvoIRNtFgq1j2114n0gS0Nq8H9FQ==,iv:JrWLVaVyrfki8l21gqavkDUp6GA8LKrQu4OfkndWQuc=,tag:8m7Aa66mpXUB3UaTk/d+wA==,type:str]
+PRODUCTS_DEMO_PATH: ENC[AES256_GCM,data:J4IQalh0Aorag+dzaiSwlTcsCXpcob439DGnjo97J+F26w==,iv:S+wUdL882eRecUaZTWttmzS+0SawOVI5I2zYVsMinEY=,tag:UazhC+1s3p+VoZSx2XkBBg==,type:str]
+SHIPMENTS_DEMO_PATH: ENC[AES256_GCM,data:2m4qxnGz2WuwN4l6jCuG33SUk/Gk9WtZ/+D9Zqz0K7L8ToA=,iv:mmS7mY6RhB0t3oyNC1VnbqFO73EE4f40eq/QkdXGbPk=,tag:HaTPHIZNJ/MzGkr2xP3Hkg==,type:str]
+#ENC[AES256_GCM,data:8rexq1Q=,iv:edOa1FzWRzgmGBEObtdADG58o5Y+lhRXXZLV7Uko0bI=,tag:pczeejU2SbEHU96B2yggAA==,type:comment]
+RESEND_API_KEY: ENC[AES256_GCM,data:1pgIJExNgKOkXzx5InqL+6u6CLnzO0I32H5yB4muS/EKAxO5,iv:E2V3dT+YQBBD78uwtGRShsiriQIw4Yu0pb4/MXDyh/Q=,tag:oUaQw/VowwzcgAUn5DCv/g==,type:str]
+RESEND_DEFAULT_EMAIL: ENC[AES256_GCM,data:q13ueCDiNeCkfavPUr8uF43XSSqKig==,iv:0GpQNeIhGIlZDQc+A8+EWhxlwe0OK4gZi1ozfzCHk0o=,tag:RufgKcNHFL5L0Ay8nqAGww==,type:str]
+RESEND_USER_EMAIL: ENC[AES256_GCM,data:GqZC1UlEWPGKz4Ib1MrxH9cBey1gmg==,iv:Vsq9LERak0Z0lrThthKmUGYQqGdwtM02Qlrky93MeoY=,tag:fV3hbyDU4jq/8Y5/y3Lp/A==,type:str]
+#ENC[AES256_GCM,data:npw7UitqLTFj,iv:GEoxn3J4Ukxn2XajOcaYXontFDzou8DMYoGd702Pcnw=,tag:fIFEj+EjaG89vK4HvXT+Qg==,type:comment]
+DATABASE_CLIENT: ENC[AES256_GCM,data:amN0yfI5MZY=,iv:D+0MUdCdcqvucIg0wYSRz4N67EDfozITkpUBJL8lCCs=,tag:3W1I3G8E/1c04DJMDW32vg==,type:str]
+DATABASE_HOST: ENC[AES256_GCM,data:qfMjcoSZhITi+j1Ff/k5ByyeZswFGwRYifr0lX3Y2kWLDMRD//jW2vur6XkeZ/Yv,iv:z7G1Pu9oWgKmQeO/yxLAUluhHgwM4EB+dyS1sxJf39I=,tag:llNU+ADlefrnnv0kLfO6Kg==,type:str]
+DATABASE_PORT: ENC[AES256_GCM,data:yS5/cVM=,iv:mUEMsnEEzJuINpngzTwXvkUiuPzG8hjE8CtyRrkO3hU=,tag:B85YgfPpQKWOJ3hvnaI4Yg==,type:int]
+DATABASE_NAME: ENC[AES256_GCM,data:7MP8xUiw,iv:fXOKbKrnoEJhjp1q5iXC+j3RByzdq4MYeP+k+if+k10=,tag:J1MNimIHcxWk7n6pNAHn3g==,type:str]
+DATABASE_USERNAME: ENC[AES256_GCM,data:Ejsew0MM,iv:VZSvHImudtyItW4vRGZZmB+csxUycoEjEIDhf1/L1jA=,tag:/cHlYpIC+VttXx8pQBzo+Q==,type:str]
+DATABASE_PASSWORD: ENC[AES256_GCM,data:elzuRJo4j+eJ/E4sBGRndGyH7ghKsGDuBzPpV7lE91cnlCc0+Trr3/Xk,iv:Iut1D9mqG+rWiG09yQSLbdkOjsnUKlMI/oT98yMz/HY=,tag:Cbwd/DeDOFNGY/BAQU1miw==,type:str]
+DATABASE_SSL: ENC[AES256_GCM,data:JlwZDw==,iv:vF8YS8jpisBU444foG+5fo4Ton6QNVeHmT4+GHfJfbs=,tag:C88BaueMFEac+b6GHjp23w==,type:bool]
+DATABASE_SSL_REJECT_UNAUTHORIZED: ENC[AES256_GCM,data:UaaNjUI=,iv:faemV8WJXDaof2dMIdvga+NVdmd2Ir2PdqX5wi1Bmag=,tag:cgI+ytFaP6PE/57HVOkaVw==,type:bool]
+DATABASE_SSL_CA: ENC[AES256_GCM,data:TTIJRnOhRETbtcmP5lAo60315GXtoCAqywxQYglihCCsktpntmJOWoaLjvDMV4WdrbNRFrcrBo5WcmRF+Pf6pqvdm70ff1tQTctUixBqung8Oi0ZWdtKyzeeUAykSAjh6+L3I9NiRBS6UpDupIL1NGW3EuZw0Ijsy9EHqiwyZDleAOOXmrlUO1xmuUDWHL1i5PaPlMnkZlQI175jStyAKFfzlWuzmSYdFXS+6oxYt7n4eXWCRRWTIc4ee0h5pD7wRJhUI3lBIODBowhY1H2GxVUrXRS85Bf8MHslUNRP4itBV4XhyI5wb/RCUDsFsv9UsIsCwISpMon2/mgsDXRBXc0/QVU/AeCNnN1geh+hg9CFXrqQbz30fqcbJQ1TehRAC4XYYWAmqETd3/J6kcmsHzZruKqK54pbWJe3w6pGa8E7jfVOo96Xnn6oXSkAz7+uOAE5akvk2dOvt7Ur0MzPoEu4pLEqAW3tLqYqdeCbTxdDDYM8doNJJVB2SwQKBV5o4pnm9ogGZqg6C5d24tW8l8e0ZaNC6iI00Hfy6VBq5rtjt/aywTYyJ8Q4lTGo9xneHSUG1b61n9CfNDQP42IMDNN30Jx1fXgepvcEcHCoBIyvvTVO8uWTv1ZG2HiSGOIH2HRIvf6cXp2IgeCKFhfE8GcdGgpEWs2PjiyEtUqhlMMLX5x06h9WvHLiYL5zw5ts4VX9N6WAngpn7dkTaZeDk+9SDX9YYeDS/wMCYAvj9sBBJAZEpc8KrsOw7SpPjLR7bx8DSbazkoXIec77d1yqOPg4Pa743U7oHWuGRl82ycQPF2GXdkH9LZGM76Pxvmk5UuQvcoteYLm/tPgf8dOhNdeajPusgJy164GLzGIx9avFIHFcAMnY/VPaQzWxZN6h4QCoxojOz3I7hJD3I6+o3s907Of8tpDVYVND7dsJovYoWh4bqGlFMEGDPQFv9frttPAeTyF2lDGfRRxPe0TP5SUbZWpVecmmEsrE1BXH77QgC8GQFMtYdjZ9bDhJhEmXTtmRSkfw8DnI+WfICThiHfN955lzrD8M7DoKbiZ2zm4F3aB/kJ6K1q0qtqyJGH5pVj4DcC2BZA3s9dllnyHjsKjX++lRLh/tWJUO6YHe4fTfjeJjyo8e3ohjQC7uhClz67iAysMbGdLSmbOoAxXG335Zczr59+GSnNbCrlgKRGyuFJdhwm/5ngLFoOMkvbnmuZX4QG45ZKA+8Tg4erFWQt7bk+g8FIZ1P/+Xac2PGe9/sUCxiewv1zX8BRkNtsglRXDIw+oBArA31OwgRyKxPKRyHNfyLbo0MBTq3LGgE5tlz+uXIVMriNMJEiMPkuFer7am6ynlLrFJ9ZzjYlgGd1Kqz1+3OnjN7eLVBI9lsTc73pIdNKpGZFe7a1a/sGJFgXjMPJHlzqjMzqQGrkMxTgFaKBJV5VfSdV4XjNL7ajxdHEvEqOJ42USww8PhlhT89armx4opvovMCO8HPs65SJLkroA+BY5nluJPtHxIX/ZkyFl9Iv9K+SWBPbGFrXyIcmklmNu0oG+3tqoU5NVDrS9uybuYGOLw49WmsLVLWFSNaSnzbqQU44BKkFqgaEZ/l+pHUyoS437UDsa1FnSlr1I2s1720YbBl8PzTB6CwmlNakKx0yWKG3V3rc8mSp3W86WfOahauOHQyJAfpvZAJN26rjtt3RLnJXlBSUpOI4n2jH4IRTYcQVvaehqBs+09zUou7diK5BYxFaSkpt+Q5pMiX+jHtCI+ZrulKP2z6DSVeWI7ScsGCcbIDv00Z1W7HHKNUaF/m5CODz49dGt5ju2MzUHCqgRDvpzQQRnsfhxkri5nx49CLjDbSDRBLLl3m1Ji/11UBvrUZmqmVBJZ/rJS5rfbtaYz/oOPNUP7vibW9Z31EstR7BatCFlHvsErNqYM/qkMeMSXYrkzb6PTinlFYK4o8f7twBA9LY8sEDrWamJOUVOuF8KkCilWzw52cIQfzMLbF3aleAPuKa80xBRoGrphPlfwsz/yfuf6SjUOAPHMP9VKhzU4uEcrRVv+Zk+TMrog9i2Al2SoY17IyVgo,iv:vzUXLZZyidOwV4eQmAgjDLDrTzuFqqIheDz81R0cnVI=,tag:pszfEs+PIJprBn5pbri8kg==,type:str]
+#ENC[AES256_GCM,data:+kIGyJ6jARg=,iv:9VBlhK+MUskDNSxx1FWqBMT7odmmDjO9au2lW3Vun9g=,tag:SPk//JvZ7XNbq6Ume1YrZw==,type:comment]
+#ENC[AES256_GCM,data:FAJF0QalhSw/p4N8GXr19qsuOLpO+Is=,iv:IBFeilwRvRiKZzYYdW6e2ki4vRmFYiBcefA4Tb0w63Q=,tag:AKujNMrdQcVVweGVhQZGjA==,type:comment]
+CLOUDINARY_KEY: ENC[AES256_GCM,data:fO4HOiQOQPeRe4kGv32Y,iv:uRA9Gb9E7gHc/wY6G3yJ3+Xb5pVFCWgC5Z9OXLdmNY8=,tag:iNJgAZ/BNSMSLk6zEroNdg==,type:int]
+CLOUDINARY_SECRET: ENC[AES256_GCM,data:9lPQ8T4pmcXZjMplEoLrFfP8Au0QgY+n1lqv,iv:hExIH93i4bOXUv1UbSrtUj8AtMB5yGiA94s9JJBRz88=,tag:u53R4Vch1r/luMDXViHoTg==,type:str]
+CLOUDINARY_NAME: ENC[AES256_GCM,data:Jpt0x2+fCGd6,iv:pOVWV68sECFmiWlzwqWQgrxgj77I5yXZ4wzeaxmjXuw=,tag:IqDx8Uau6ssLs+GUmgi2lw==,type:str]
+CLOUDINARY_FOLDER: ENC[AES256_GCM,data:43gkdZShGwlqz6RRwMOPmWY5zWlSiJyz1rIyPH6dSB0Ov2q29Ll8fw==,iv:X66M7Fjc7HLzWj1x6zYfkjuoTqCkQaCpIuCfVi8tfUk=,tag:whHxtlM6jW+lwXO8gWVllQ==,type:str]
+sops:
+    age:
+        - recipient: age198gq0jfpeju4hceg3cez9mqpufe9h08upx95e2f70cr3dklttqts35ch5t
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwQ0RsOVRoUFV5RVROU25G
+            dHRudXhRVU41dnBXMU4xSjJFVG1IYnZoYlNzCldNSjlwanBGTStJaFI1azc5TXNt
+            SEJFaHZJYzdMQzZ0N3ZsMi9EMDhCNDgKLS0tIHhrUW9LRDBqZnNhZDFEbmxZUFYz
+            V2pmUG42Tm4vVitxcTFiLytXU2s4WE0KC2E8Q/3hQVLRBsqiQ/Rrpsc+Miti0oC6
+            DAw75N+uJxawCE/uIOvi4axrlWYGxli9XVNwH3uVSNbYcVsv/1OoyQ==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age16z3ewnx22h4j4qxmaj43yysag8a3gnxs46mm9p0s92lcykwr952syq8365
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxYmNlam5uUnpubTI0NDd0
+            Um5yUlZXYmxZalUvd2FkOXNkSVlzZVQ4UWxRCktqTGhhTU5vdmQ0b0h5NnFHWHFv
+            Zk1sdkxPNkFub1FXWjdIa013V1pSOWMKLS0tIFZFM2wrQ1ZRQUdnMDhLYkhWbkI5
+            eE5qTVI4aFpLRHFDdDN3dDNCNFRKYUUKjXAbdo3vUIzNALvkFLvQdgYOCW82WNpl
+            fengf9kzNpDQGZCq+Y5/UvtsSZW9PPZzZOvtKhpjMdiCE80sAK9XCw==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1k349xhtvfswn44wprj03pnlxafry0y2uyl23hy3e8zpxavjaysmqg62q9y
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBtYkhrbHc5Nk5mdDllV1dy
+            bnY1MHE1c1B0RmgwUWpjclhPcitzYmtQdFhRCkJESm9oZ0FrU1EwekFPa2paSnZj
+            cE4rbGhiMjhwMGowV09tSTUrT2Q4ME0KLS0tIFZIMlhvM250M2xUSnVHOWhSaUVX
+            K3VRUDhnWkdrZ2l4MjdFWXZiaGFDQncKjgHt4H4kOrw5uLcJAZV2ye6RAGvSu9ca
+            YPNIUMpecs6V84YSSeusuo1T/PzXEqlB8RL+tzzfmcu4ijSx8vfkLw==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-04-02T17:44:49Z"
+    mac: ENC[AES256_GCM,data:ZfmaDkalrd2tvDZeqUjZ9GkyP8JUDk3UW9ES9R4CKnFJedCSm/sWQKdd1Ab1fWhvOhjiz9/t7kI/QEPU5geWcj72bkK3c4/49BA8fCVGnSiGQcgdmTBjP7zoClLM2KEcoEwbldF462Qs0GOGxX29ViuKpGtYHDYbjQAAHfCjHxY=,iv:h1vhVsCPjp151LfSjOeUcOt/g9202OPGnMPRnxdcD/I=,tag:aJbMlQ9ZHfX4gsgGEKl01w==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.12.1


### PR DESCRIPTION
## What changed?
Adding the encrypted prod SOPS file after testing deployment on Staging.
This will unlock prod deployments using the GHA deploy workflow.
<!-- include a link to a GitHub issue, if applicable -->

## How can you test this?
