### PR TITLE
chore/537/update module settings

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "module": "CommonJS",
-    "moduleResolution": "Node",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "lib": ["ES2020"],
     "target": "ES2019",
     "strict": false,


### PR DESCRIPTION
Fixes #537

## What changed?

- Updated the tsconfig.json file to use nodenext module settings, resolving node10 deprecation in TypeScript 7.0.

## How can you test this?

1. Check out the branch `config/537/update-tsconfig-module-settings`.
2. Install dependencies with the command `yarn install`.
3. Run the code with the command `yarn develop`.
4. Verify the Strapi admin is built and running free of errors with the node module changes.