### PR TITLE
feat/541/update the duration component

### DIFF
--- a/src/components/time/duration.json
+++ b/src/components/time/duration.json
@@ -6,12 +6,12 @@
   },
   "options": {},
   "attributes": {
-    "Start": {
-      "type": "datetime",
+    "start": {
+      "type": "date",
       "required": true
     },
-    "End": {
-      "type": "datetime",
+    "end": {
+      "type": "date",
       "required": false
     }
   }

--- a/types/generated/components.d.ts
+++ b/types/generated/components.d.ts
@@ -219,8 +219,8 @@ export interface TimeDuration extends Struct.ComponentSchema {
     icon: "clock";
   };
   attributes: {
-    End: Schema.Attribute.DateTime;
-    Start: Schema.Attribute.DateTime & Schema.Attribute.Required;
+    end: Schema.Attribute.Date;
+    start: Schema.Attribute.Date & Schema.Attribute.Required;
   };
 }
 


### PR DESCRIPTION
Fixes #541

## What changed?

Updated the `start` and `end` fields for this component. Changed it from **datetime** to **date**.
~~Added descriptive helper text to the `end` field, noting to leave the input empty if currently working in the role.~~
See this [comment](https://github.com/distributeaid/aggregated-public-information/pull/543#issuecomment-4566328191) below regarding the descriptive helper text.

Resolves Issue [#541](https://github.com/distributeaid/aggregated-public-information/issues/541)

## How can you test this?
### View the changes in the code editor:

1. Check out the branch `feat/541/update-duration-component`.
2. Open `src/components/time/duration.json` to view the changes. 
3. In `types/generated/components.d.ts`, verify the changes to the `start` and `end` fields in the attributes block (near line 221).

### View the component in the Strapi admin panel:

1. Run `yarn install` to install the applicable dependencies.
2. Run `yarn develop` to start Strapi and build the admin panel.
3. In the Strapi admin panel, go to **Content-Type Builder**.
4. Scroll down to the **Components** section.
5. Locate the **Time** category.
6. Select the **Duration** component and verify that the `start` and `end` fields are now a **date** content-type.