### PR TITLE
Feat/539/refine Strapi Team.Member collection

### DIFF
--- a/src/api/team/content-types/member/schema.json
+++ b/src/api/team/content-types/member/schema.json
@@ -9,6 +9,7 @@
   "options": {
     "draftAndPublish": true
   },
+  "pluginOptions": {},
   "attributes": {
     "Name": {
       "type": "string",
@@ -22,9 +23,11 @@
       "type": "media",
       "multiple": false,
       "required": true,
-      "allowedTypes": ["images"]
+      "allowedTypes": [
+        "images"
+      ]
     },
-    "From": {
+    "homeCountry": {
       "type": "relation",
       "relation": "oneToOne",
       "target": "api::geo.country"
@@ -34,8 +37,8 @@
     },
     "Roles": {
       "type": "component",
-      "repeatable": true,
       "component": "team.role",
+      "repeatable": true,
       "required": true
     }
   }

--- a/src/api/team/content-types/member/schema.json
+++ b/src/api/team/content-types/member/schema.json
@@ -23,9 +23,7 @@
       "type": "media",
       "multiple": false,
       "required": true,
-      "allowedTypes": [
-        "images"
-      ]
+      "allowedTypes": ["images"]
     },
     "homeCountry": {
       "type": "relation",

--- a/src/api/team/content-types/member/schema.json
+++ b/src/api/team/content-types/member/schema.json
@@ -11,15 +11,15 @@
   },
   "pluginOptions": {},
   "attributes": {
-    "Name": {
+    "name": {
       "type": "string",
       "required": true,
       "unique": true
     },
-    "Pronouns": {
+    "pronouns": {
       "type": "string"
     },
-    "Profile": {
+    "profile": {
       "type": "media",
       "multiple": false,
       "required": true,
@@ -32,10 +32,10 @@
       "relation": "oneToOne",
       "target": "api::geo.country"
     },
-    "Bio": {
+    "bio": {
       "type": "richtext"
     },
-    "Roles": {
+    "roles": {
       "type": "component",
       "component": "team.role",
       "repeatable": true,

--- a/src/components/team/role.json
+++ b/src/components/team/role.json
@@ -7,7 +7,7 @@
   },
   "options": {},
   "attributes": {
-    "Title": {
+    "title": {
       "type": "string",
       "required": true
     },
@@ -35,7 +35,7 @@
       "relation": "oneToOne",
       "target": "api::geo.country"
     },
-    "Duration": {
+    "duration": {
       "type": "component",
       "component": "time.duration",
       "repeatable": false

--- a/types/generated/components.d.ts
+++ b/types/generated/components.d.ts
@@ -209,14 +209,14 @@ export interface TeamRole extends Struct.ComponentSchema {
       "oneToOne",
       "api::geo.country"
     >;
-    Duration: Schema.Attribute.Component<"time.duration", false>;
+    duration: Schema.Attribute.Component<"time.duration", false>;
     team: Schema.Attribute.JSON &
       Schema.Attribute.CustomField<
         "plugin::multi-select.multi-select",
         ["admin", "operations", "stories", "tech", "design", "fundraising"]
       > &
       Schema.Attribute.DefaultTo<"[]">;
-    Title: Schema.Attribute.String & Schema.Attribute.Required;
+    title: Schema.Attribute.String & Schema.Attribute.Required;
     type: Schema.Attribute.Enumeration<
       ["board member", "director", "coordinator", "volunteer"]
     > &

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -1079,7 +1079,7 @@ export interface ApiTeamMember extends Struct.CollectionTypeSchema {
     draftAndPublish: true;
   };
   attributes: {
-    Bio: Schema.Attribute.RichText;
+    bio: Schema.Attribute.RichText;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
       Schema.Attribute.Private;
@@ -1087,13 +1087,13 @@ export interface ApiTeamMember extends Struct.CollectionTypeSchema {
     locale: Schema.Attribute.String & Schema.Attribute.Private;
     localizations: Schema.Attribute.Relation<"oneToMany", "api::team.member"> &
       Schema.Attribute.Private;
-    Name: Schema.Attribute.String &
+    name: Schema.Attribute.String &
       Schema.Attribute.Required &
       Schema.Attribute.Unique;
-    Profile: Schema.Attribute.Media<"images"> & Schema.Attribute.Required;
-    Pronouns: Schema.Attribute.String;
+    profile: Schema.Attribute.Media<"images"> & Schema.Attribute.Required;
+    pronouns: Schema.Attribute.String;
     publishedAt: Schema.Attribute.DateTime;
-    Roles: Schema.Attribute.Component<"team.role", true> &
+    roles: Schema.Attribute.Component<"team.role", true> &
       Schema.Attribute.Required;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -1083,7 +1083,7 @@ export interface ApiTeamMember extends Struct.CollectionTypeSchema {
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
       Schema.Attribute.Private;
-    From: Schema.Attribute.Relation<"oneToOne", "api::geo.country">;
+    homeCountry: Schema.Attribute.Relation<"oneToOne", "api::geo.country">;
     locale: Schema.Attribute.String & Schema.Attribute.Private;
     localizations: Schema.Attribute.Relation<"oneToMany", "api::team.member"> &
       Schema.Attribute.Private;


### PR DESCRIPTION
Fixes #539

## What changed?

- Renamed the `from` **relation** field to `homeCountry`.
- Updated all field names to lowercase in the collection, as well as all field names in components used in the collection.

## How can you test this?
### View the changes in the code editor:

1. Check out the branch `feat/539/refine-team-collection`.
2. Open `src/api/team/content-types/member/schema.json` to view the changes.

### View the collection in the Strapi admin panel:

1. Run `yarn install` to install the applicable dependencies.
2. Run `yarn develop` to start Strapi and build the admin panel.
3. In the Strapi admin panel, go to **Content-Type Builder**.
4. Under COLLECTION TYPES, select the **Team.Member** collection.
5. Verify the newly named `homeCountry` **relation** field.
6. Confirm all field names are lowercase.

### Add an entry and test the endpoint with an API request:

1. In the Strapi admin panel, go to **Content Manager**.
2. Scroll down to **Team.Member** and select this collection.
3. Click **Create new entry**.
4. Fill in **all required fields** and any optional fields you want to test.
5. Click **Save**, then click **Publish**.
6. Click **Back** at the top to return to the collection list and confirm your entry appears.
7. Open an **API test tool** (such as Postman, Bruno or another HTTP client).
8. Send a **GET** request to one of the following endpoints:
    ```
     http://localhost:1337/api/members?populate=* 
    ```
   >Use this endpoint for a quick test. It populates all first-level relations but **does not** fully populate nested relations within    components (e.g., certain fields within roles).

    ```
    http://localhost:1337/api/members?populate=homeCountry&populate=profile&populate=roles.associatedCountry&populate=roles.duration
    ``` 
    >Use this endpoint with **nested populate parameters** to retrieve the full data set, including:

    - Relations (`homeCountry`, `associatedCountry`)
    - Media (`profile`)
    - Nested components (`roles.duration`)
9. Verify that: 
- The response status is `200 OK`. 
- The response body contains your newly created entry with the desired data.