### PR TITLE
Feat/526/create response collection

### DIFF
--- a/src/api/response/content-types/overview/schema.json
+++ b/src/api/response/content-types/overview/schema.json
@@ -18,6 +18,11 @@
     "description": {
       "type": "text"
     },
+    "imageGallery": {
+      "type": "component",
+      "component": "response.image-reference",
+      "repeatable": true
+    },
     "processImageMobile": {
       "type": "media",
       "multiple": false,

--- a/src/api/response/content-types/overview/schema.json
+++ b/src/api/response/content-types/overview/schema.json
@@ -31,6 +31,11 @@
       "allowedTypes": [
         "images"
       ]
+    },
+    "callToActionCards": {
+      "type": "component",
+      "component": "response.call-to-action",
+      "repeatable": true
     }
   }
 }

--- a/src/api/response/content-types/overview/schema.json
+++ b/src/api/response/content-types/overview/schema.json
@@ -26,16 +26,12 @@
     "processImageMobile": {
       "type": "media",
       "multiple": false,
-      "allowedTypes": [
-        "images"
-      ]
+      "allowedTypes": ["images"]
     },
     "processImageDesktop": {
       "type": "media",
       "multiple": false,
-      "allowedTypes": [
-        "images"
-      ]
+      "allowedTypes": ["images"]
     },
     "callToActionCards": {
       "type": "component",

--- a/src/api/response/content-types/overview/schema.json
+++ b/src/api/response/content-types/overview/schema.json
@@ -1,0 +1,36 @@
+{
+  "kind": "collectionType",
+  "collectionName": "overviews",
+  "info": {
+    "singularName": "overview",
+    "pluralName": "overviews",
+    "displayName": "Response.Overview"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "name": {
+      "type": "string",
+      "required": true
+    },
+    "description": {
+      "type": "text"
+    },
+    "processImageMobile": {
+      "type": "media",
+      "multiple": false,
+      "allowedTypes": [
+        "images"
+      ]
+    },
+    "processImageDesktop": {
+      "type": "media",
+      "multiple": false,
+      "allowedTypes": [
+        "images"
+      ]
+    }
+  }
+}

--- a/src/api/response/controllers/overview.ts
+++ b/src/api/response/controllers/overview.ts
@@ -1,0 +1,7 @@
+/**
+ * response controller
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::response.overview');

--- a/src/api/response/controllers/overview.ts
+++ b/src/api/response/controllers/overview.ts
@@ -2,6 +2,6 @@
  * response controller
  */
 
-import { factories } from '@strapi/strapi';
+import { factories } from "@strapi/strapi";
 
-export default factories.createCoreController('api::response.overview');
+export default factories.createCoreController("api::response.overview");

--- a/src/api/response/routes/overview.ts
+++ b/src/api/response/routes/overview.ts
@@ -2,6 +2,6 @@
  * response router
  */
 
-import { factories } from '@strapi/strapi';
+import { factories } from "@strapi/strapi";
 
-export default factories.createCoreRouter('api::response.overview');
+export default factories.createCoreRouter("api::response.overview");

--- a/src/api/response/routes/overview.ts
+++ b/src/api/response/routes/overview.ts
@@ -1,0 +1,7 @@
+/**
+ * response router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::response.overview');

--- a/src/api/response/services/overview.ts
+++ b/src/api/response/services/overview.ts
@@ -2,6 +2,6 @@
  * response service
  */
 
-import { factories } from '@strapi/strapi';
+import { factories } from "@strapi/strapi";
 
-export default factories.createCoreService('api::response.overview');
+export default factories.createCoreService("api::response.overview");

--- a/src/api/response/services/overview.ts
+++ b/src/api/response/services/overview.ts
@@ -1,0 +1,7 @@
+/**
+ * response service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::response.overview');

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -1068,6 +1068,37 @@ export interface ApiReportingShipment extends Struct.CollectionTypeSchema {
   };
 }
 
+export interface ApiResponseOverview extends Struct.CollectionTypeSchema {
+  collectionName: "overviews";
+  info: {
+    displayName: "Response.Overview";
+    pluralName: "overviews";
+    singularName: "overview";
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+    description: Schema.Attribute.Text;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      "oneToMany",
+      "api::response.overview"
+    > &
+      Schema.Attribute.Private;
+    name: Schema.Attribute.String & Schema.Attribute.Required;
+    processImageDesktop: Schema.Attribute.Media<"images">;
+    processImageMobile: Schema.Attribute.Media<"images">;
+    publishedAt: Schema.Attribute.DateTime;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+  };
+}
+
 export interface ApiTeamMember extends Struct.CollectionTypeSchema {
   collectionName: "members";
   info: {
@@ -1662,6 +1693,7 @@ declare module "@strapi/strapi" {
       "api::reporting.cargo": ApiReportingCargo;
       "api::reporting.movement": ApiReportingMovement;
       "api::reporting.shipment": ApiReportingShipment;
+      "api::response.overview": ApiResponseOverview;
       "api::team.member": ApiTeamMember;
       "plugin::content-releases.release": PluginContentReleasesRelease;
       "plugin::content-releases.release-action": PluginContentReleasesReleaseAction;

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -1087,6 +1087,7 @@ export interface ApiResponseOverview extends Struct.CollectionTypeSchema {
     createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
       Schema.Attribute.Private;
     description: Schema.Attribute.Text;
+    imageGallery: Schema.Attribute.Component<"response.image-reference", true>;
     locale: Schema.Attribute.String & Schema.Attribute.Private;
     localizations: Schema.Attribute.Relation<
       "oneToMany",

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -1079,6 +1079,10 @@ export interface ApiResponseOverview extends Struct.CollectionTypeSchema {
     draftAndPublish: true;
   };
   attributes: {
+    callToActionCards: Schema.Attribute.Component<
+      "response.call-to-action",
+      true
+    >;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
       Schema.Attribute.Private;


### PR DESCRIPTION
Fixes #526 

## What changed?
Created a **Response.Overview** collection for the response pages that will be viewable on the frontend.
Added the following fields to the collection:

- name
- description
- imageGallery (repeatable component)
- processImageMobile (this is for the "How it works" flowchart - mobile version)
- processImageDesktop (this is for the "How it works" flowchart - desktop version)
- callToActionCards (repeatable component)

**Partially** resolves [Issue #526](https://github.com/distributeaid/aggregated-public-information/issues/526)

## How can you test this?
### Confirm the Collection in Content Manager

1. In the navigation bar, select **Content Manager**.
2. Confirm the collection appears in the list and select it.
3. Click **Create new entry**.
4. Enter values for the collection fields.
5. Click **Publish**. 
6. Confirm that:
      - The name/title appears above the entry.
      - The entry appears in the list for that collection (select **Back** to verify).

### Verify the API Endpoint Returns Data

1. Open an API test tool (for example, Postman or Bruno).
2. Send a GET request to the collection endpoint:
```bash
   http://localhost:1337/api/overviews?populate=*
   ```
3. Confirm that:
   - The response status is a `200 OK`.
   - The `data` array contains the entry or entries you created.
   - Nested data is included when `?populate=*` is used.